### PR TITLE
Aggregate function pushdown to different decoders

### DIFF
--- a/src/storage/blocksstable/encoding/ob_const_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_const_decoder.cpp
@@ -271,6 +271,122 @@ int ObConstDecoder::get_null_count(
   return ret;
 }
 
+int ObConstDecoder::get_aggregate_result(
+    const ObColumnDecoderCtx &ctx,
+    const ObIRowIndex *row_index,
+    const int64_t *row_ids,
+    const int64_t row_cap,
+    ObMicroBlockAggInfo<ObDatum> &agg_info,
+    ObDatum *datum_buf) const 
+{
+  UNUSEDx(row_index);
+  int ret = OB_SUCCESS;
+  const int64_t count = meta_header_->count_;
+  const int64_t const_ref = meta_header_->const_ref_;
+  const ObIntArrayFuncTable &row_id_arr
+      = ObIntArrayFuncTable::instance(meta_header_->row_id_byte_);
+  bool const_nu = false;
+  const int64_t dict_meta_length = ctx.col_header_->length_ - meta_header_->offset_;
+  int64_t dict_count = dict_decoder_.get_dict_header()->count_;
+  if (const_ref == dict_count) {
+    // Const value is null
+    LOG_INFO("No const", K(ret));
+    const_nu = true;
+  } else {
+    // Const value is not null
+    ObDictDecoderIterator dict_iter = dict_decoder_.begin(&ctx, dict_meta_length);
+    ObObj& const_obj = *(dict_iter + meta_header_->const_ref_);
+    if (const_obj.is_fixed_len_char_type() && nullptr != ctx.col_param_) {
+      if (OB_FAIL(storage::pad_column(ctx.col_param_->get_accuracy(),
+                  *ctx.allocator_, const_obj))) {
+        LOG_WARN("Failed to pad column", K(ret));
+      } else {
+      }
+    }
+    if (OB_FAIL(datum_buf[0].from_obj(const_obj))){
+      LOG_WARN("Failed to trans to datum");
+    } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[0]))){
+      LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[0]), K(agg_info));
+    }
+  }
+  if (OB_SUCC(ret)) {
+    ObDictDecoderIterator begin_it = dict_decoder_.begin(&ctx, dict_meta_length);
+    ObDictDecoderIterator end_it = dict_decoder_.end(&ctx, dict_meta_length);
+    ObDictDecoderIterator trav_it = begin_it;
+    if(row_cap == ctx.micro_block_header_->row_count_){
+      int64_t i = 1;
+      while (OB_SUCC(ret) && trav_it != end_it) {
+        if (OB_UNLIKELY(((*trav_it).is_null_oracle() && lib::is_oracle_mode())
+                        || ((*trav_it).is_null() && lib::is_mysql_mode()))) {
+          ret = OB_ERR_UNEXPECTED;
+          LOG_WARN("There should not be null object in dictionary", K(ret));
+        } else if (OB_FAIL(datum_buf[i].from_obj(*trav_it))){
+          LOG_WARN("Failed to trans to datum");
+        } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
+          LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
+        }
+        ++trav_it;
+        ++i;
+      }
+    } else {
+      int64_t row_id = 0;
+      int64_t except_table_pos = 0;
+      const int64_t dict_meta_length = ctx.col_header_->length_ - meta_header_->offset_;
+      int64_t next_except_row_id = row_id_arr.at_(meta_header_->payload_ + count, except_table_pos);
+      bool monotonic_inc = true;
+      if (row_cap > 1) {
+        monotonic_inc = row_ids[1] > row_ids[0];
+      }
+      int64_t step = monotonic_inc ? 1 : -1;
+      int64_t trav_idx = monotonic_inc ? 0 : row_cap - 1;
+      int64_t trav_cnt = 0;
+      int64_t i =1;
+      common::ObObj cell;
+      uint32_t ref;
+      while (trav_cnt < row_cap) {
+        row_id = row_ids[trav_idx];
+        uint32_t *curr_ref =  &ref ;
+        if (except_table_pos == count || row_id < next_except_row_id) {
+        } else if (row_id == next_except_row_id) {
+          *curr_ref = reinterpret_cast<const uint8_t *>(meta_header_->payload_)[except_table_pos];
+          ++except_table_pos;
+          if (except_table_pos < count) {
+            next_except_row_id = row_id_arr.at_(meta_header_->payload_ + count, except_table_pos);
+          }
+          cell = *(begin_it + *curr_ref);
+          if (OB_FAIL(datum_buf[i].from_obj(cell))){
+            LOG_WARN("Failed to trans to datum");
+          } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
+            LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
+          }
+        } else {
+          except_table_pos = row_id_arr.lower_bound_(
+                meta_header_->payload_ + count, 0, count, row_id);
+          next_except_row_id = row_id_arr.at_(meta_header_->payload_ + count, except_table_pos);
+          if (except_table_pos == count || row_id != next_except_row_id) {
+          } else {
+            *curr_ref = reinterpret_cast<const uint8_t *>(meta_header_->payload_)[except_table_pos];
+            ++except_table_pos;
+            if (except_table_pos < count) {
+              next_except_row_id = row_id_arr.at_(meta_header_->payload_ + count, except_table_pos);
+            }
+            cell = *(begin_it + *curr_ref);
+            if (OB_FAIL(datum_buf[i].from_obj(cell))){
+              LOG_WARN("Failed to trans to datum");
+            } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
+              LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
+            }
+          }
+        }
+        ++trav_cnt;
+        ++i;
+        trav_idx += step;
+      }
+    }
+  }
+  return ret;
+}
+
 int ObConstDecoder::pushdown_operator(
     const sql::ObPushdownFilterExecutor *parent,
     const ObColumnDecoderCtx &col_ctx,

--- a/src/storage/blocksstable/encoding/ob_const_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_const_decoder.cpp
@@ -273,39 +273,32 @@ int ObConstDecoder::get_null_count(
 
 int ObConstDecoder::get_aggregate_result(
     const ObColumnDecoderCtx &ctx,
-    const ObIRowIndex *row_index,
     const int64_t *row_ids,
     const int64_t row_cap,
     ObMicroBlockAggInfo<ObDatum> &agg_info,
     ObDatum *datum_buf) const 
 {
-  UNUSEDx(row_index);
   int ret = OB_SUCCESS;
   const int64_t count = meta_header_->count_;
   const int64_t const_ref = meta_header_->const_ref_;
-  bool const_nu = false;
   const int64_t dict_meta_length = ctx.col_header_->length_ - meta_header_->offset_;
   if(0 ==count){
     ObObj const_obj;
     if(OB_FAIL(decode_without_dict(ctx, const_obj))){
-      LOG_WARN("Failed to decode without dict");
-    }
-    else if (const_obj.is_fixed_len_char_type() && nullptr != ctx.col_param_) {
+      LOG_WARN("Failed to decode without dict",K(ret),K(ctx));
+    } else if (const_obj.is_fixed_len_char_type() && nullptr != ctx.col_param_) {
       if (OB_FAIL(storage::pad_column(ctx.col_param_->get_accuracy(),
                   *ctx.allocator_, const_obj))) {
         LOG_WARN("Failed to pad column", K(ret));
-      } else {
+      } else if (OB_FAIL(datum_buf[0].from_obj(const_obj))){
+        LOG_WARN("Failed to trans to datum",K(ret),K(const_obj));
+      } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[0]))){
+        LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[0]), K(agg_info));
       }
-    }
-    if (OB_FAIL(datum_buf[0].from_obj(const_obj))){
-      LOG_WARN("Failed to trans to datum");
-    } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[0]))){
-      LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[0]), K(agg_info));
     }
   } else if (const_ref ==  dict_decoder_.get_dict_header()->count_) {
     // Const value is null
     LOG_INFO("No const", K(ret));
-    const_nu = true;
   } else {
     // Const value is not null
     ObDictDecoderIterator dict_iter = dict_decoder_.begin(&ctx, dict_meta_length);
@@ -314,13 +307,11 @@ int ObConstDecoder::get_aggregate_result(
       if (OB_FAIL(storage::pad_column(ctx.col_param_->get_accuracy(),
                   *ctx.allocator_, const_obj))) {
         LOG_WARN("Failed to pad column", K(ret));
-      } else {
+      }  else if (OB_FAIL(datum_buf[0].from_obj(const_obj))){
+        LOG_WARN("Failed to trans to datum",K(ret),K(const_obj));
+      } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[0]))){
+        LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[0]), K(agg_info));
       }
-    }
-    if (OB_FAIL(datum_buf[0].from_obj(const_obj))){
-      LOG_WARN("Failed to trans to datum");
-    } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[0]))){
-      LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[0]), K(agg_info));
     }
   }
 
@@ -336,7 +327,7 @@ int ObConstDecoder::get_aggregate_result(
           ret = OB_ERR_UNEXPECTED;
           LOG_WARN("There should not be null object in dictionary", K(ret));
         } else if (OB_FAIL(datum_buf[i].from_obj(*trav_it))){
-          LOG_WARN("Failed to trans to datum");
+          LOG_WARN("Failed to trans to datum",K(ret),K(*trav_it));
         } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
           LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
         }
@@ -360,7 +351,7 @@ int ObConstDecoder::get_aggregate_result(
       int64_t i =1;
       common::ObObj cell;
       uint32_t ref;
-      while (trav_cnt < row_cap) {
+      while (OB_SUCC(ret) && trav_cnt < row_cap) {
         row_id = row_ids[trav_idx];
         uint32_t *curr_ref =  &ref ;
         if (except_table_pos == count || row_id < next_except_row_id) {
@@ -372,7 +363,7 @@ int ObConstDecoder::get_aggregate_result(
           }
           cell = *(begin_it + *curr_ref);
           if (OB_FAIL(datum_buf[i].from_obj(cell))){
-            LOG_WARN("Failed to trans to datum");
+            LOG_WARN("Failed to trans to datum",K(ret),K(cell));
           } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
             LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
           }
@@ -389,7 +380,7 @@ int ObConstDecoder::get_aggregate_result(
             }
             cell = *(begin_it + *curr_ref);
             if (OB_FAIL(datum_buf[i].from_obj(cell))){
-              LOG_WARN("Failed to trans to datum");
+              LOG_WARN("Failed to trans to datum",K(ret),K(cell));
             } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
               LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
             }

--- a/src/storage/blocksstable/encoding/ob_const_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_const_decoder.cpp
@@ -287,10 +287,8 @@ int ObConstDecoder::get_aggregate_result(
     if (OB_FAIL(decode_without_dict(ctx, const_obj))){
       LOG_WARN("Failed to decode without dict",K(ret),K(ctx));
     } else {
-      if (OB_FAIL(datum_buf[0].from_obj(const_obj))){
-        LOG_WARN("Failed to trans to datum",K(ret),K(const_obj));
-      } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[0]))){
-        LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[0]), K(agg_info));
+      if(OB_FAIL(ObIColumnDecoder::update_agg_from_obj(const_obj, agg_info, datum_buf[0]))){
+        LOG_WARN("Failed to update_min_or_max");
       }
     }
   } else if (const_ref ==  dict_decoder_.get_dict_header()->count_) {
@@ -299,11 +297,9 @@ int ObConstDecoder::get_aggregate_result(
     // Const value is not null
     ObDictDecoderIterator dict_iter = dict_decoder_.begin(&ctx, dict_meta_length);
     ObObj& const_obj = *(dict_iter + meta_header_->const_ref_);
-      if (OB_FAIL(datum_buf[0].from_obj(const_obj))){
-        LOG_WARN("Failed to trans to datum",K(ret),K(const_obj));
-      } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[0]))){
-        LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[0]), K(agg_info));
-      }
+    if(OB_FAIL(ObIColumnDecoder::update_agg_from_obj(const_obj, agg_info, datum_buf[0]))){
+      LOG_WARN("Failed to update_min_or_max");
+    }
   }
 
   if (OB_SUCC(ret) && count > 0) {
@@ -317,10 +313,8 @@ int ObConstDecoder::get_aggregate_result(
                         || ((*trav_it).is_null() && lib::is_mysql_mode()))) {
           ret = OB_ERR_UNEXPECTED;
           LOG_WARN("There should not be null object in dictionary", K(ret));
-        } else if (OB_FAIL(datum_buf[i].from_obj(*trav_it))){
-          LOG_WARN("Failed to trans to datum",K(ret),K(*trav_it));
-        } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
-          LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
+        } else if(OB_FAIL(ObIColumnDecoder::update_agg_from_obj(*trav_it, agg_info, datum_buf[0]))){
+          LOG_WARN("Failed to update_min_or_max");
         }
         ++trav_it;
         ++i;
@@ -358,10 +352,8 @@ int ObConstDecoder::get_aggregate_result(
               next_except_row_id = row_id_arr.at_(meta_header_->payload_ + count, except_table_pos);
             }
             cell = *(begin_it + *curr_ref);
-            if (OB_FAIL(datum_buf[i].from_obj(cell))){
-              LOG_WARN("Failed to trans to datum",K(ret),K(cell));
-            } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
-              LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
+            if(OB_FAIL(ObIColumnDecoder::update_agg_from_obj(cell, agg_info, datum_buf[0]))){
+              LOG_WARN("Failed to update_min_or_max");
             }
           }
         } 

--- a/src/storage/blocksstable/encoding/ob_const_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_const_decoder.cpp
@@ -284,7 +284,7 @@ int ObConstDecoder::get_aggregate_result(
   const int64_t dict_meta_length = ctx.col_header_->length_ - meta_header_->offset_;
   if(0 ==count){
     ObObj const_obj;
-    if(OB_FAIL(decode_without_dict(ctx, const_obj))){
+    if (OB_FAIL(decode_without_dict(ctx, const_obj))){
       LOG_WARN("Failed to decode without dict",K(ret),K(ctx));
     } else if (const_obj.is_fixed_len_char_type() && nullptr != ctx.col_param_) {
       if (OB_FAIL(storage::pad_column(ctx.col_param_->get_accuracy(),

--- a/src/storage/blocksstable/encoding/ob_const_decoder.h
+++ b/src/storage/blocksstable/encoding/ob_const_decoder.h
@@ -64,6 +64,14 @@ public:
       const int64_t row_cap,
       int64_t &null_count) const override;
 
+  virtual int get_aggregate_result(
+      const ObColumnDecoderCtx &ctx,
+      const ObIRowIndex *row_index,
+      const int64_t *row_ids,
+      const int64_t row_cap,
+      ObMicroBlockAggInfo<ObDatum> &agg_info,
+      ObDatum *datum_buf) const override;
+
   virtual int pushdown_operator(
       const sql::ObPushdownFilterExecutor *parent,
       const ObColumnDecoderCtx &col_ctx,

--- a/src/storage/blocksstable/encoding/ob_const_decoder.h
+++ b/src/storage/blocksstable/encoding/ob_const_decoder.h
@@ -66,7 +66,6 @@ public:
 
   virtual int get_aggregate_result(
       const ObColumnDecoderCtx &ctx,
-      const ObIRowIndex *row_index,
       const int64_t *row_ids,
       const int64_t row_cap,
       ObMicroBlockAggInfo<ObDatum> &agg_info,

--- a/src/storage/blocksstable/encoding/ob_dict_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_dict_decoder.cpp
@@ -674,17 +674,15 @@ int ObDictDecoder::get_aggregate_result(
         ref = 0;
         if (OB_FAIL(read_ref(row_id, ctx.is_bit_packing(), col_data, ref))) {
             LOG_WARN("Failed to read reference for dictionary", K(ret), K(col_data), K(row_id));
-        } else {
-          if ((ref < count) && !ref_map.test(ref)){
-              if(OB_FAIL(decode(ctx.obj_meta_, cell, ref, ctx.col_header_->length_))){
-                LOG_WARN("Failed to decode", K(ret), K(ref), K(ctx.obj_meta_));
-              } else if (OB_FAIL(datum_buf[i].from_obj(cell))){
-                LOG_WARN("Failed to trans to datum",K(ret),K(cell));
-              } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
-                LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
-              }
-            ref_map.set(ref);
-          }
+        } else if ((ref < count) && !ref_map.test(ref)){
+            if(OB_FAIL(decode(ctx.obj_meta_, cell, ref, ctx.col_header_->length_))){
+              LOG_WARN("Failed to decode", K(ret), K(ref), K(ctx.obj_meta_));
+            } else if (OB_FAIL(datum_buf[i].from_obj(cell))){
+              LOG_WARN("Failed to trans to datum",K(ret),K(cell));
+            } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
+              LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
+            }
+          ref_map.set(ref);
         }
       }
     }

--- a/src/storage/blocksstable/encoding/ob_dict_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_dict_decoder.cpp
@@ -603,15 +603,12 @@ int ObDictDecoder::get_null_count(
 
 int ObDictDecoder::get_aggregate_result(
     const ObColumnDecoderCtx &ctx,
-    const ObIRowIndex *row_index,
     const int64_t *row_ids,
     const int64_t row_cap,
     ObMicroBlockAggInfo<ObDatum> &agg_info,
     ObDatum *datum_buf) const
 {
-  UNUSEDx(row_index);
   int ret = OB_SUCCESS;
-  ObObj cell;
   if (OB_UNLIKELY(!is_inited())) {
     ret = OB_NOT_INIT;
     LOG_WARN("Dict decoder not inited", K(ret));
@@ -629,15 +626,15 @@ int ObDictDecoder::get_aggregate_result(
         traverse_it = begin_it + 1;
       }
       if (OB_FAIL(datum_buf[0].from_obj(*traverse_it))){
-        LOG_WARN("Failed to trans to datum");
+        LOG_WARN("Failed to trans to datum",K(ret),K(*traverse_it));
       } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[0]))){
         LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[0]), K(agg_info));
       }
     } else {
       int64_t i = 0;
-      for (; traverse_it != end_it; ++traverse_it){
+      for (; OB_SUCC(ret) && traverse_it != end_it; ++traverse_it){
         if (OB_FAIL(datum_buf[i].from_obj(*traverse_it))){
-          LOG_WARN("Failed to trans to datum");
+          LOG_WARN("Failed to trans to datum",K(ret),K(*traverse_it));
         } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
           LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
         }
@@ -651,27 +648,32 @@ int ObDictDecoder::get_aggregate_result(
     int64_t row_id = 0;
     int64_t ref = 0;
     int64_t res_ref = 0;
+    ObObj cell;
     const int64_t count = meta_header_->count_;
-    for (int64_t i = 0; i < row_cap; ++i) {
+    for (int64_t i = 0; OB_SUCC(ret) && i < row_cap; ++i) {
       row_id = row_ids[i];
       ref = 0;
-      read_ref(row_id, ctx.is_bit_packing(), col_data, ref);
-      if((ref < count) && (res_ref != ref)){
-        if(meta_header_->is_sorted_dict()){
-          if((!agg_info.get_is_min() && res_ref < ref) || (agg_info.get_is_min() && res_ref > ref)){
+      if (OB_FAIL(read_ref(row_id, ctx.is_bit_packing(), col_data, ref))) {
+          LOG_WARN("Failed to read reference for dictionary", K(ret), K(col_data), K(row_id));
+      } else {
+        if((ref < count) && (res_ref != ref)){
+          if(meta_header_->is_sorted_dict()){
+            if((!agg_info.get_is_min() && res_ref < ref) 
+                || (agg_info.get_is_min() && res_ref > ref)){
+              decode(ctx.obj_meta_, cell, ref, ctx.col_header_->length_);
+              if (OB_FAIL(datum_buf[i].from_obj(cell))){
+                LOG_WARN("Failed to trans to datum",K(ret),K(cell));
+              } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
+                LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
+              }
+            }
+          } else {
             decode(ctx.obj_meta_, cell, ref, ctx.col_header_->length_);
             if (OB_FAIL(datum_buf[i].from_obj(cell))){
-              LOG_WARN("Failed to trans to datum");
+              LOG_WARN("Failed to trans to datum",K(ret),K(cell));
             } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
               LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
             }
-          }
-        } else {
-          decode(ctx.obj_meta_, cell, ref, ctx.col_header_->length_);
-          if (OB_FAIL(datum_buf[i].from_obj(cell))){
-            LOG_WARN("Failed to trans to datum");
-          } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
-            LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
           }
         }
       }

--- a/src/storage/blocksstable/encoding/ob_dict_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_dict_decoder.cpp
@@ -625,17 +625,13 @@ int ObDictDecoder::get_aggregate_result(
       } else if ((*traverse_it).is_null()) {
         traverse_it = begin_it + 1;
       }
-      if (OB_FAIL(datum_buf[0].from_obj(*traverse_it))){
-        LOG_WARN("Failed to trans to datum",K(ret),K(*traverse_it));
-      } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[0]))){
-        LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[0]), K(agg_info));
-      }
+        if(OB_FAIL(ObIColumnDecoder::update_agg_from_obj(*traverse_it, agg_info, datum_buf[0]))){
+          LOG_WARN("Failed to update_min_or_max");
+        }
     } else {
       for (int64_t i = 0; OB_SUCC(ret) && traverse_it != end_it; ++traverse_it, ++i ){
-        if (OB_FAIL(datum_buf[i].from_obj(*traverse_it))){
-          LOG_WARN("Failed to trans to datum",K(ret),K(*traverse_it));
-        } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
-          LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
+        if(OB_FAIL(ObIColumnDecoder::update_agg_from_obj(*traverse_it, agg_info, datum_buf[i]))){
+          LOG_WARN("Failed to update_min_or_max");
         }
       }   
     }  
@@ -661,10 +657,8 @@ int ObDictDecoder::get_aggregate_result(
       }
       if(OB_FAIL(decode(ctx.obj_meta_, cell, res_ref, ctx.col_header_->length_))){
         LOG_WARN("Failed to decode", K(ret), K(res_ref), K(ctx.obj_meta_));
-      } else if (OB_FAIL(datum_buf[0].from_obj(cell))){
-        LOG_WARN("Failed to trans to datum",K(ret),K(cell));
-      } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[0]))){
-        LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[0]), K(agg_info));
+      } else if(OB_FAIL(ObIColumnDecoder::update_agg_from_obj(cell, agg_info, datum_buf[0]))){
+        LOG_WARN("Failed to update_min_or_max");
       }
     } else {
       ObBitmap ref_map(*ctx.allocator_);
@@ -675,13 +669,11 @@ int ObDictDecoder::get_aggregate_result(
         if (OB_FAIL(read_ref(row_id, ctx.is_bit_packing(), col_data, ref))) {
             LOG_WARN("Failed to read reference for dictionary", K(ret), K(col_data), K(row_id));
         } else if ((ref < count) && !ref_map.test(ref)){
-            if(OB_FAIL(decode(ctx.obj_meta_, cell, ref, ctx.col_header_->length_))){
-              LOG_WARN("Failed to decode", K(ret), K(ref), K(ctx.obj_meta_));
-            } else if (OB_FAIL(datum_buf[i].from_obj(cell))){
-              LOG_WARN("Failed to trans to datum",K(ret),K(cell));
-            } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
-              LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
-            }
+          if(OB_FAIL(decode(ctx.obj_meta_, cell, ref, ctx.col_header_->length_))){
+            LOG_WARN("Failed to decode", K(ret), K(ref), K(ctx.obj_meta_));
+          } else if(OB_FAIL(ObIColumnDecoder::update_agg_from_obj(cell, agg_info, datum_buf[0]))){
+            LOG_WARN("Failed to update_min_or_max");
+          }
           ref_map.set(ref);
         }
       }

--- a/src/storage/blocksstable/encoding/ob_dict_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_dict_decoder.cpp
@@ -601,6 +601,85 @@ int ObDictDecoder::get_null_count(
   return ret;
 }
 
+int ObDictDecoder::get_aggregate_result(
+    const ObColumnDecoderCtx &ctx,
+    const ObIRowIndex *row_index,
+    const int64_t *row_ids,
+    const int64_t row_cap,
+    ObMicroBlockAggInfo<ObDatum> &agg_info,
+    ObDatum *datum_buf) const
+{
+  UNUSEDx(row_index);
+  int ret = OB_SUCCESS;
+  ObObj cell;
+  if (OB_UNLIKELY(!is_inited())) {
+    ret = OB_NOT_INIT;
+    LOG_WARN("Dict decoder not inited", K(ret));
+  } else if(row_cap == ctx.micro_block_header_->row_count_){
+    ObDictDecoderIterator begin_it = begin(&ctx, ctx.col_header_->length_);
+    ObDictDecoderIterator end_it = end(&ctx, ctx.col_header_->length_);
+    ObDictDecoderIterator traverse_it = begin_it;
+    if (meta_header_->is_sorted_dict()) {
+      if (!agg_info.get_is_min()) {
+        traverse_it = end_it;
+        if((*traverse_it).is_null()){
+          traverse_it = end_it - 1;
+        }
+      } else if ((*traverse_it).is_null()) {
+        traverse_it = begin_it + 1;
+      }
+      if (OB_FAIL(datum_buf[0].from_obj(*traverse_it))){
+        LOG_WARN("Failed to trans to datum");
+      } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[0]))){
+        LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[0]), K(agg_info));
+      }
+    } else {
+      int64_t i = 0;
+      for (; traverse_it != end_it; ++traverse_it){
+        if (OB_FAIL(datum_buf[i].from_obj(*traverse_it))){
+          LOG_WARN("Failed to trans to datum");
+        } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
+          LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
+        }
+        ++i;
+      }   
+    }  
+  } else {
+    const unsigned char *col_data = reinterpret_cast<unsigned char *>(
+        const_cast<ObDictMetaHeader *>(meta_header_)) + ctx.col_header_->length_;
+    const uint8_t row_ref_size = meta_header_->row_ref_size_;
+    int64_t row_id = 0;
+    int64_t ref = 0;
+    int64_t res_ref = 0;
+    const int64_t count = meta_header_->count_;
+    for (int64_t i = 0; i < row_cap; ++i) {
+      row_id = row_ids[i];
+      ref = 0;
+      read_ref(row_id, ctx.is_bit_packing(), col_data, ref);
+      if((ref < count) && (res_ref != ref)){
+        if(meta_header_->is_sorted_dict()){
+          if((!agg_info.get_is_min() && res_ref < ref) || (agg_info.get_is_min() && res_ref > ref)){
+            decode(ctx.obj_meta_, cell, ref, ctx.col_header_->length_);
+            if (OB_FAIL(datum_buf[i].from_obj(cell))){
+              LOG_WARN("Failed to trans to datum");
+            } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
+              LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
+            }
+          }
+        } else {
+          decode(ctx.obj_meta_, cell, ref, ctx.col_header_->length_);
+            if (OB_FAIL(datum_buf[i].from_obj(cell))){
+              LOG_WARN("Failed to trans to datum");
+            } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
+              LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
+            }
+        }
+      }
+    }
+  }
+  return ret;
+}
+
 int ObDictDecoder::update_pointer(const char *old_block, const char *cur_block)
 {
   int ret = OB_SUCCESS;

--- a/src/storage/blocksstable/encoding/ob_dict_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_dict_decoder.cpp
@@ -668,11 +668,11 @@ int ObDictDecoder::get_aggregate_result(
           }
         } else {
           decode(ctx.obj_meta_, cell, ref, ctx.col_header_->length_);
-            if (OB_FAIL(datum_buf[i].from_obj(cell))){
-              LOG_WARN("Failed to trans to datum");
-            } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
-              LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
-            }
+          if (OB_FAIL(datum_buf[i].from_obj(cell))){
+            LOG_WARN("Failed to trans to datum");
+          } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
+            LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
+          }
         }
       }
     }

--- a/src/storage/blocksstable/encoding/ob_dict_decoder.h
+++ b/src/storage/blocksstable/encoding/ob_dict_decoder.h
@@ -18,6 +18,7 @@
 #include "ob_integer_array.h"
 #include "ob_dict_encoder.h"
 #include "sql/engine/ob_bit_vector.h"
+#include "storage/blocksstable/ob_imicro_block_reader.h"
 
 namespace oceanbase
 {
@@ -82,6 +83,14 @@ public:
       const int64_t *row_ids,
       const int64_t row_cap,
       int64_t &null_count) const override;
+
+  virtual int get_aggregate_result(
+      const ObColumnDecoderCtx &ctx,
+      const ObIRowIndex *row_index,
+      const int64_t *row_ids,
+      const int64_t row_cap,
+      ObMicroBlockAggInfo<ObDatum> &agg_info,
+      ObDatum *datum_buf) const override;
 
   virtual int update_pointer(const char *old_block, const char *cur_block) override;
 

--- a/src/storage/blocksstable/encoding/ob_dict_decoder.h
+++ b/src/storage/blocksstable/encoding/ob_dict_decoder.h
@@ -86,7 +86,6 @@ public:
 
   virtual int get_aggregate_result(
       const ObColumnDecoderCtx &ctx,
-      const ObIRowIndex *row_index,
       const int64_t *row_ids,
       const int64_t row_cap,
       ObMicroBlockAggInfo<ObDatum> &agg_info,

--- a/src/storage/blocksstable/encoding/ob_icolumn_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_icolumn_decoder.cpp
@@ -276,5 +276,20 @@ int ObIColumnDecoder::get_aggregate_result(
   return ret;
 }
 
+int ObIColumnDecoder::update_agg_from_obj(
+      const common::ObObj cell,
+      ObMicroBlockAggInfo<ObDatum> &agg_info,
+      ObDatum datum) const
+{
+  int ret = OB_SUCCESS;
+  if (OB_FAIL(datum.from_obj(cell))){
+    LOG_WARN("Failed to trans to datum",K(ret),K(cell));
+  } else if (OB_FAIL(agg_info.update_min_or_max(datum))){
+    LOG_WARN("Failed to update_min_or_max", K(ret), K(datum), K(agg_info));
+  }
+  return ret;
+}
+
+
 } // end of namespace oceanbase
 } // end of namespace oceanbase

--- a/src/storage/blocksstable/encoding/ob_icolumn_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_icolumn_decoder.cpp
@@ -267,34 +267,27 @@ int ObIColumnDecoder::get_null_count_from_extend_value(
 
 int ObIColumnDecoder::get_aggregate_result(
   const ObColumnDecoderCtx &ctx,
-  const ObIRowIndex *row_index,
   const int64_t *row_ids,
   const int64_t row_cap,
   ObMicroBlockAggInfo<ObDatum> &agg_info,
   ObDatum *datum) const
 {
   int ret = OB_SUCCESS;
-  ObObj cell;
-  sql::ObWhiteFilterOperatorType op_type = sql::WHITE_OP_LT;
-  bool const_nu = false;
-  const char *row_data = NULL;
-  int64_t row_len = 0;
-  int64_t row_id = 0;
-  for (int64_t i = 0; OB_SUCC(ret) && i < row_cap; ++i) {
-    row_id = row_ids[i];
-    if (OB_FAIL(row_index->get(row_id, row_data, row_len))) {
-      LOG_WARN("get row data failed", K(ret), K(row_id));
-    }
-    ObBitStream bs(reinterpret_cast<unsigned char *>(const_cast<char *>(row_data)), row_len);
-    if (OB_FAIL(ret)) {
-    } else if (OB_FAIL(decode(const_cast<ObColumnDecoderCtx &>(ctx), cell, row_id, bs, row_data, row_len))) {
-      LOG_WARN("Failed to decode cell", K(ret));
-    } else  if(OB_FAIL(datum[i].from_obj(cell))){
-      LOG_WARN("Failed to get datum from obj");
-    } else if (OB_FAIL(agg_info.update_min_or_max(datum[i]))){
-      LOG_WARN("Failed to update_min_or_max");
-    }
-    }
+  switch (ctx.col_header_->type_){
+    //supported type
+    case ObColumnHeader::RAW :
+    case ObColumnHeader::DICT :
+    case ObColumnHeader::RLE :
+    case ObColumnHeader::CONST :
+    case ObColumnHeader::INTEGER_BASE_DIFF: break;
+    //unsupported type
+    case ObColumnHeader::STRING_DIFF:
+    case ObColumnHeader::STRING_PREFIX:
+    case ObColumnHeader::HEX_PACKING:
+    case ObColumnHeader::COLUMN_EQUAL:
+    case ObColumnHeader::COLUMN_SUBSTR: 
+    ret = OB_NOT_SUPPORTED;
+  }
   return ret;
 }
 

--- a/src/storage/blocksstable/encoding/ob_icolumn_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_icolumn_decoder.cpp
@@ -272,22 +272,7 @@ int ObIColumnDecoder::get_aggregate_result(
   ObMicroBlockAggInfo<ObDatum> &agg_info,
   ObDatum *datum) const
 {
-  int ret = OB_SUCCESS;
-  switch (ctx.col_header_->type_){
-    //supported type
-    case ObColumnHeader::RAW :
-    case ObColumnHeader::DICT :
-    case ObColumnHeader::RLE :
-    case ObColumnHeader::CONST :
-    case ObColumnHeader::INTEGER_BASE_DIFF: break;
-    //unsupported type
-    case ObColumnHeader::STRING_DIFF:
-    case ObColumnHeader::STRING_PREFIX:
-    case ObColumnHeader::HEX_PACKING:
-    case ObColumnHeader::COLUMN_EQUAL:
-    case ObColumnHeader::COLUMN_SUBSTR: 
-    ret = OB_NOT_SUPPORTED;
-  }
+  int ret = OB_NOT_SUPPORTED;
   return ret;
 }
 

--- a/src/storage/blocksstable/encoding/ob_icolumn_decoder.h
+++ b/src/storage/blocksstable/encoding/ob_icolumn_decoder.h
@@ -201,7 +201,6 @@ public:
 
   virtual int get_aggregate_result(
       const ObColumnDecoderCtx &ctx,
-      const ObIRowIndex *row_index,
       const int64_t *row_ids,
       const int64_t row_cap,
       ObMicroBlockAggInfo<ObDatum> &agg_info,

--- a/src/storage/blocksstable/encoding/ob_icolumn_decoder.h
+++ b/src/storage/blocksstable/encoding/ob_icolumn_decoder.h
@@ -23,6 +23,7 @@
 #include "ob_encoding_util.h"
 #include "ob_row_index.h"
 #include "storage/blocksstable/ob_micro_block_header.h"
+#include "storage/blocksstable/ob_imicro_block_reader.h"
 
 namespace oceanbase
 {
@@ -198,6 +199,13 @@ public:
       const int64_t row_cap,
       int64_t &null_count) const;
 
+  virtual int get_aggregate_result(
+      const ObColumnDecoderCtx &ctx,
+      const ObIRowIndex *row_index,
+      const int64_t *row_ids,
+      const int64_t row_cap,
+      ObMicroBlockAggInfo<ObDatum> &agg_info,
+      ObDatum *datum_buf) const; 
 protected:
   int get_null_count_from_extend_value(
     const ObColumnDecoderCtx &ctx,

--- a/src/storage/blocksstable/encoding/ob_icolumn_decoder.h
+++ b/src/storage/blocksstable/encoding/ob_icolumn_decoder.h
@@ -205,6 +205,12 @@ public:
       const int64_t row_cap,
       ObMicroBlockAggInfo<ObDatum> &agg_info,
       ObDatum *datum_buf) const; 
+
+  virtual int update_agg_from_obj(
+      const common::ObObj cell,
+      ObMicroBlockAggInfo<ObDatum> &agg_info,
+      ObDatum datum_buf) const; 
+
 protected:
   int get_null_count_from_extend_value(
     const ObColumnDecoderCtx &ctx,

--- a/src/storage/blocksstable/encoding/ob_integer_base_diff_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_integer_base_diff_decoder.cpp
@@ -602,7 +602,6 @@ int ObIntegerBaseDiffDecoder::get_null_count(
 }
 int ObIntegerBaseDiffDecoder::get_aggregate_result(
       const ObColumnDecoderCtx &ctx,
-      const ObIRowIndex *row_index,
       const int64_t *row_ids,
       const int64_t row_cap,
       ObMicroBlockAggInfo<ObDatum> &agg_info,
@@ -610,13 +609,12 @@ int ObIntegerBaseDiffDecoder::get_aggregate_result(
 {
   int ret = OB_SUCCESS;
   uint32_t datum_len = 0;
+
   if (OB_FAIL(get_uint_data_datum_len(
       ObDatum::get_obj_datum_map_type(ctx.obj_meta_.get_type()),
       datum_len))) {
     LOG_WARN("Failed to get datum length of int/uint data", K(ret));
-  }
-  ObObj cell;
-  if(agg_info.get_is_min() && (row_cap == ctx.micro_block_header_->row_count_)){
+  } else if (agg_info.get_is_min() && (row_cap == ctx.micro_block_header_->row_count_)){
     MEMCPY(const_cast<char *>(datum_buf[0].ptr_), &base_, datum_len);
     datum_buf[0].pack_ = datum_len;
     if (OB_FAIL(agg_info.update_min_or_max(datum_buf[0]))){
@@ -635,9 +633,8 @@ int ObIntegerBaseDiffDecoder::get_aggregate_result(
         LOG_WARN("Failed to set null datums from fixed data", K(ret), K(ctx));
       }
     }
-
     if (OB_FAIL(ret)) {
-    }  else if (ctx.is_bit_packing()) {
+    } else if (ctx.is_bit_packing()) {
       if (OB_FAIL(batch_get_bitpacked_values(
           ctx, row_ids, row_cap, datum_len, data_offset, datum_buf))) {
         LOG_WARN("Failed to batch unpack delta values", K(ret), K(ctx));

--- a/src/storage/blocksstable/encoding/ob_integer_base_diff_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_integer_base_diff_decoder.cpp
@@ -600,6 +600,82 @@ int ObIntegerBaseDiffDecoder::get_null_count(
   }
   return ret;
 }
+int ObIntegerBaseDiffDecoder::get_aggregate_result(
+      const ObColumnDecoderCtx &ctx,
+      const ObIRowIndex *row_index,
+      const int64_t *row_ids,
+      const int64_t row_cap,
+      ObMicroBlockAggInfo<ObDatum> &agg_info,
+      ObDatum *datum_buf) const 
+{
+  int ret = OB_SUCCESS;
+  uint32_t datum_len = 0;
+  if (OB_FAIL(get_uint_data_datum_len(
+      ObDatum::get_obj_datum_map_type(ctx.obj_meta_.get_type()),
+      datum_len))) {
+    LOG_WARN("Failed to get datum length of int/uint data", K(ret));
+  }
+  ObObj cell;
+  if(agg_info.get_is_min() && (row_cap == ctx.micro_block_header_->row_count_)){
+    MEMCPY(const_cast<char *>(datum_buf[0].ptr_), &base_, datum_len);
+    datum_buf[0].pack_ = datum_len;
+    if (OB_FAIL(agg_info.update_min_or_max(datum_buf[0]))){
+      LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[0]), K(agg_info));
+    }
+  } else {
+    int64_t data_offset = 0;
+    const unsigned char *col_data = reinterpret_cast<const unsigned char *>(header_)
+                                    + ctx.col_header_->length_;
+
+    if (ctx.has_extend_value()) {
+      data_offset = ctx.micro_block_header_->row_count_
+          * ctx.micro_block_header_->extend_value_bit_;
+      if (OB_FAIL(set_null_datums_from_fixed_column(
+          ctx, row_ids, row_cap, col_data, datum_buf))) {
+        LOG_WARN("Failed to set null datums from fixed data", K(ret), K(ctx));
+      }
+    }
+
+    if (OB_FAIL(ret)) {
+    }  else if (ctx.is_bit_packing()) {
+      if (OB_FAIL(batch_get_bitpacked_values(
+          ctx, row_ids, row_cap, datum_len, data_offset, datum_buf))) {
+        LOG_WARN("Failed to batch unpack delta values", K(ret), K(ctx));
+      }
+      for (int64_t i = 0; i < row_cap; ++i) {
+        if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
+          LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
+        }
+      }
+    } else {
+      // Fixed store data
+      data_offset = (data_offset + CHAR_BIT - 1) / CHAR_BIT;
+      int64_t row_id = 0;
+      uint64_t value = 0;
+      uint64_t res_value = 0;
+      bool is_min = agg_info.get_is_min();
+      for (int64_t i = 0; i < row_cap; ++i) {
+        if (ctx.has_extend_value() && datum_buf[i].is_null()) {
+          // Skip
+        } else {
+          row_id = row_ids[i];
+          value = 0;
+          MEMCPY(&value, col_data + data_offset + row_id * header_->length_, header_->length_);
+          if((is_min && value < res_value) || (!is_min && value > res_value)){
+            res_value = value;
+          }
+        }
+      }
+      res_value += base_;
+      MEMCPY(const_cast<char *>(datum_buf[0].ptr_), &res_value, datum_len);
+      datum_buf[0].pack_ = datum_len;
+      if (OB_FAIL(agg_info.update_min_or_max(datum_buf[0]))){
+        LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[0]), K(agg_info));
+      }
+    }
+  }
+  return ret;
+}
 
 } // end namespace blocksstable
 } // end namespace oceanbase

--- a/src/storage/blocksstable/encoding/ob_integer_base_diff_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_integer_base_diff_decoder.cpp
@@ -658,7 +658,7 @@ int ObIntegerBaseDiffDecoder::get_aggregate_result(
           row_id = row_ids[i];
           value = 0;
           MEMCPY(&value, col_data + data_offset + row_id * header_->length_, header_->length_);
-          if((is_min && value < res_value) || (!is_min && value > res_value)){
+          if (( is_min && value < res_value) || (!is_min && value > res_value)){
             res_value = value;
           }
         }

--- a/src/storage/blocksstable/encoding/ob_integer_base_diff_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_integer_base_diff_decoder.cpp
@@ -609,7 +609,6 @@ int ObIntegerBaseDiffDecoder::get_aggregate_result(
 {
   int ret = OB_SUCCESS;
   uint32_t datum_len = 0;
-
   if (OB_FAIL(get_uint_data_datum_len(
       ObDatum::get_obj_datum_map_type(ctx.obj_meta_.get_type()),
       datum_len))) {
@@ -652,7 +651,7 @@ int ObIntegerBaseDiffDecoder::get_aggregate_result(
       uint64_t res_value = 0;
       bool is_min = agg_info.get_is_min();
       for (int64_t i = 0; i < row_cap; ++i) {
-        if (ctx.has_extend_value() && datum_buf[i].is_null()) {
+        if (ctx.has_extend_value()) {
           // Skip
         } else {
           row_id = row_ids[i];

--- a/src/storage/blocksstable/encoding/ob_integer_base_diff_decoder.h
+++ b/src/storage/blocksstable/encoding/ob_integer_base_diff_decoder.h
@@ -72,6 +72,14 @@ public:
       const int64_t *row_ids,
       const int64_t row_cap,
       int64_t &null_count) const override;
+
+  virtual int get_aggregate_result(
+      const ObColumnDecoderCtx &ctx,
+      const ObIRowIndex *row_index,
+      const int64_t *row_ids,
+      const int64_t row_cap,
+      ObMicroBlockAggInfo<ObDatum> &agg_info,
+      ObDatum *datum_buf) const override;
 private:
   int batch_get_bitpacked_values(
       const ObColumnDecoderCtx &ctx,

--- a/src/storage/blocksstable/encoding/ob_integer_base_diff_decoder.h
+++ b/src/storage/blocksstable/encoding/ob_integer_base_diff_decoder.h
@@ -75,7 +75,6 @@ public:
 
   virtual int get_aggregate_result(
       const ObColumnDecoderCtx &ctx,
-      const ObIRowIndex *row_index,
       const int64_t *row_ids,
       const int64_t row_cap,
       ObMicroBlockAggInfo<ObDatum> &agg_info,

--- a/src/storage/blocksstable/encoding/ob_micro_block_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_micro_block_decoder.cpp
@@ -1451,7 +1451,7 @@ OB_INLINE int ObMicroBlockDecoder::get_row_impl(int64_t index, ObDatumRow &row)
     } else if (row.get_capacity() < request_cnt_) {
       ret = OB_BUF_NOT_ENOUGH;
       LOG_WARN("obj buf is not enough", K(ret), "expect_obj_count", request_cnt_, K(row));
-    } else if (OB_FAIL(decode_cells(index, row_len, row_data, 0, request_cnt_, row.storage_datums_))) {
+    } else if (OB_FAIL(decode_cells(index, row_len, row_data, 0, MIN(request_cnt_, header_->column_count_), row.storage_datums_))) {
       LOG_WARN("decode cells failed", K(ret), K(index), K_(request_cnt));
     } else {
       row.row_flag_.reset();
@@ -2144,20 +2144,34 @@ int ObMicroBlockDecoder::get_min_or_max(
 {
   int ret = OB_SUCCESS;
   decoder_allocator_.reuse();
-  if (OB_FAIL(get_col_datums(col_id, row_ids, cell_datas, row_cap, datum_buf))) {
-    LOG_WARN("Failed to get col datums", K(ret), K(col_id), K(row_cap));
+  STORAGE_LOG(INFO, "resue allocator sucessful");
+  common::ObObj cell;
+  STORAGE_LOG(INFO, "before get",K(col_header_->type_),K(*ctxs_[col_id]),K(row_index_),K(row_ids),K(row_cap),K(agg_info));
+  if (OB_FAIL(decoders_[col_id].decoder_->get_min_or_max(*ctxs_[col_id],row_index_,row_ids,row_cap,cell,agg_info.get_is_min()))){
+    LOG_WARN("Failed to get obj", K(ret), K(col_id), K(row_cap));
+  } else if (OB_FAIL(datum_buf[0].from_obj(cell))){
+    LOG_WARN("Failed to trans to datum", K(ret), K(cell), K(datum_buf[0]));
+  } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[0]))) {
+    LOG_WARN("fail to update_min_or_max", K(ret), K(datum_buf[0]), K(agg_info));
   } else {
-    for (int64_t i = 0; OB_SUCC(ret) && i < row_cap; ++i) {
-      if (datum_buf[i].is_nop()) {
-        ret = OB_ERR_UNEXPECTED;
-        LOG_WARN("unexpected datum, can not process in batch", K(ret), K(i));
-      } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))) {
-        LOG_WARN("fail to update_min_or_max", K(ret), K(i), K(datum_buf[i]), K(agg_info));
-      } else {
-        LOG_DEBUG("update min/max", K(i), K(datum_buf[i]), K(agg_info));
-      }
-    }
+    LOG_DEBUG("update min/max", K(0), K(datum_buf[0]), K(agg_info));
   }
+    
+
+  // if (OB_FAIL(get_col_datums(col_id, row_ids, cell_datas, row_cap, datum_buf))) {
+  //   LOG_WARN("Failed to get col datums", K(ret), K(col_id), K(row_cap));
+  // } else {
+  //   for (int64_t i = 0; OB_SUCC(ret) && i < row_cap; ++i) {
+  //     if (datum_buf[i].is_nop()) {
+  //       ret = OB_ERR_UNEXPECTED;
+  //       LOG_WARN("unexpected datum, can not process in batch", K(ret), K(i));
+  //     } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))) {
+  //       LOG_WARN("fail to update_min_or_max", K(ret), K(i), K(datum_buf[i]), K(agg_info));
+  //     } else {
+  //       LOG_DEBUG("update min/max", K(i), K(datum_buf[i]), K(agg_info));
+  //     }
+  //   }
+  // }
   return ret;
 }
 

--- a/src/storage/blocksstable/encoding/ob_micro_block_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_micro_block_decoder.cpp
@@ -2151,20 +2151,23 @@ int ObMicroBlockDecoder::get_min_or_max(
   } else {
     if (OB_FAIL(decoders_[col_id].decoder_->get_aggregate_result(
           *column_decoder->ctx_,row_ids,row_cap,agg_info,datum_buf))){
-      LOG_WARN("Unsupported encoding type to get aggregate result", K(ret), K(col_id), K(row_cap));
-      if (OB_FAIL(get_col_datums(col_id, row_ids, cell_datas, row_cap, datum_buf))) {
-        LOG_WARN("Failed to get col datums", K(ret), K(col_id), K(row_cap));
+      if(ret == OB_NOT_SUPPORTED){
+        if (OB_FAIL(get_col_datums(col_id, row_ids, cell_datas, row_cap, datum_buf))) {
+          LOG_WARN("Failed to get col datums", K(ret), K(col_id), K(row_cap));
+        } else {
+          for (int64_t i = 0; OB_SUCC(ret) && i < row_cap; ++i) {
+            if (datum_buf[i].is_nop()) {
+              ret = OB_ERR_UNEXPECTED;
+              LOG_WARN("unexpected datum, can not process in batch", K(ret), K(i));
+            } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))) {
+              LOG_WARN("fail to update_min_or_max", K(ret), K(i), K(datum_buf[i]), K(agg_info));
+            } else {
+              LOG_DEBUG("update min/max", K(i), K(datum_buf[i]), K(agg_info));
+            }
+          } 
+        }
       } else {
-        for (int64_t i = 0; OB_SUCC(ret) && i < row_cap; ++i) {
-          if (datum_buf[i].is_nop()) {
-            ret = OB_ERR_UNEXPECTED;
-            LOG_WARN("unexpected datum, can not process in batch", K(ret), K(i));
-          } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))) {
-            LOG_WARN("fail to update_min_or_max", K(ret), K(i), K(datum_buf[i]), K(agg_info));
-          } else {
-            LOG_DEBUG("update min/max", K(i), K(datum_buf[i]), K(agg_info));
-          }
-        } 
+        LOG_WARN("Failed to get aggregate result", K(ret), K(col_id), K(row_cap));
       }
     }
   }

--- a/src/storage/blocksstable/encoding/ob_micro_block_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_micro_block_decoder.cpp
@@ -2149,8 +2149,8 @@ int ObMicroBlockDecoder::get_min_or_max(
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("Null pointer of column decoder", K(ret));
   } else {
-    if (OB_FAIL(decoders_[col_id].decoder_
-        ->get_aggregate_result(*column_decoder->ctx_,row_ids,row_cap,agg_info,datum_buf))){
+    if (OB_FAIL(decoders_[col_id].decoder_->get_aggregate_result(
+          *column_decoder->ctx_,row_ids,row_cap,agg_info,datum_buf))){
       LOG_WARN("Unsupported encoding type to get aggregate result", K(ret), K(col_id), K(row_cap));
       if (OB_FAIL(get_col_datums(col_id, row_ids, cell_datas, row_cap, datum_buf))) {
         LOG_WARN("Failed to get col datums", K(ret), K(col_id), K(row_cap));

--- a/src/storage/blocksstable/encoding/ob_micro_block_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_micro_block_decoder.cpp
@@ -2144,34 +2144,17 @@ int ObMicroBlockDecoder::get_min_or_max(
 {
   int ret = OB_SUCCESS;
   decoder_allocator_.reuse();
-  STORAGE_LOG(INFO, "resue allocator sucessful");
-  common::ObObj cell;
-  STORAGE_LOG(INFO, "before get",K(col_header_->type_),K(*ctxs_[col_id]),K(row_index_),K(row_ids),K(row_cap),K(agg_info));
-  if (OB_FAIL(decoders_[col_id].decoder_->get_min_or_max(*ctxs_[col_id],row_index_,row_ids,row_cap,cell,agg_info.get_is_min()))){
-    LOG_WARN("Failed to get obj", K(ret), K(col_id), K(row_cap));
-  } else if (OB_FAIL(datum_buf[0].from_obj(cell))){
-    LOG_WARN("Failed to trans to datum", K(ret), K(cell), K(datum_buf[0]));
-  } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[0]))) {
-    LOG_WARN("fail to update_min_or_max", K(ret), K(datum_buf[0]), K(agg_info));
+  ObColumnDecoder* column_decoder = nullptr;
+  if (OB_ISNULL(column_decoder = decoders_ + col_id)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("Null pointer of column decoder", K(ret));
   } else {
-    LOG_DEBUG("update min/max", K(0), K(datum_buf[0]), K(agg_info));
+    if (OB_FAIL(decoders_[col_id].decoder_->get_aggregate_result(*column_decoder->ctx_,row_index_,row_ids,row_cap,agg_info,datum_buf))){
+      LOG_WARN("Failed to get aggregate_result", K(ret), K(col_id), K(row_cap));
+    } else {
+      LOG_DEBUG("update min/max", K(0), K(agg_info));
+    }
   }
-    
-
-  // if (OB_FAIL(get_col_datums(col_id, row_ids, cell_datas, row_cap, datum_buf))) {
-  //   LOG_WARN("Failed to get col datums", K(ret), K(col_id), K(row_cap));
-  // } else {
-  //   for (int64_t i = 0; OB_SUCC(ret) && i < row_cap; ++i) {
-  //     if (datum_buf[i].is_nop()) {
-  //       ret = OB_ERR_UNEXPECTED;
-  //       LOG_WARN("unexpected datum, can not process in batch", K(ret), K(i));
-  //     } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))) {
-  //       LOG_WARN("fail to update_min_or_max", K(ret), K(i), K(datum_buf[i]), K(agg_info));
-  //     } else {
-  //       LOG_DEBUG("update min/max", K(i), K(datum_buf[i]), K(agg_info));
-  //     }
-  //   }
-  // }
   return ret;
 }
 

--- a/src/storage/blocksstable/encoding/ob_raw_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_raw_decoder.cpp
@@ -199,14 +199,12 @@ template <bool IS_SIGNED_SC, int32_t STORE_LEN_TAG, int32_t DATUM_LEN_TAG, int32
 struct RawFixIntGetMinMaxFunc_T
 {
   static void raw_fix_int_get_min_or_max_func(
-      const int64_t col_len,
       const char *base_data,
       const int64_t *row_ids,
       const int64_t row_cap,
       bool is_min,
       ObDatum &datum)
   {
-    UNUSED(col_len);
     typedef typename ObEncodingTypeInference<IS_SIGNED_SC, STORE_LEN_TAG>::Type StoreType;
     typedef typename ObEncodingTypeInference<IS_SIGNED_SC, DATUM_LEN_TAG>::Type DatumType;
     const StoreType *input = reinterpret_cast<const StoreType *>(base_data);
@@ -731,7 +729,7 @@ int ObRawDecoder::get_aggregate_result(
         [get_value_len_tag_map()[store_len]]
         [get_value_len_tag_map()[get_datum_store_len(map_type)]]
         [get_store_class_tag_map()[store_class]];
-      get_min_or_max_func(ctx.col_header_->length_, meta_data_, row_ids, row_cap, agg_info.get_is_min(), datum_buf[0]);
+      get_min_or_max_func(meta_data_, row_ids, row_cap, agg_info.get_is_min(), datum_buf[0]);
     if (OB_FAIL(agg_info.update_min_or_max(datum_buf[0]))){
       LOG_WARN("Failed to update_min_or_max",K(ret),K(datum_buf[0]));
     }

--- a/src/storage/blocksstable/encoding/ob_raw_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_raw_decoder.cpp
@@ -709,7 +709,6 @@ int ObRawDecoder::get_null_count(
 
 int ObRawDecoder::get_aggregate_result(
       const ObColumnDecoderCtx &ctx,
-      const ObIRowIndex *row_index,
       const int64_t *row_ids,
       const int64_t row_cap,
       ObMicroBlockAggInfo<ObDatum> &agg_info,
@@ -734,12 +733,11 @@ int ObRawDecoder::get_aggregate_result(
         [get_store_class_tag_map()[store_class]];
       get_min_or_max_func(ctx.col_header_->length_, meta_data_, row_ids, row_cap, agg_info.get_is_min(), datum_buf[0]);
     if (OB_FAIL(agg_info.update_min_or_max(datum_buf[0]))){
-      LOG_WARN("Failed to update_min_or_max");
+      LOG_WARN("Failed to update_min_or_max",K(ret),K(datum_buf[0]));
     }
   } else {
-    if(OB_FAIL(ObIColumnDecoder::get_aggregate_result(ctx, row_index, row_ids, row_cap, agg_info,datum_buf))){
-      LOG_WARN("Fail to get min/max from column decoder");
-    }
+    ret = OB_NOT_SUPPORTED;
+    LOG_WARN("Unsupported store class in raw encoding",K(ret));
   }
   return ret;
 }

--- a/src/storage/blocksstable/encoding/ob_raw_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_raw_decoder.cpp
@@ -206,7 +206,7 @@ struct RawFixIntGetMinMaxFunc_T
       ObDatum &datum)
   {
     typedef typename ObEncodingTypeInference<IS_SIGNED_SC, STORE_LEN_TAG>::Type StoreType;
-    typedef typename ObEncodingTypeInference<IS_SIGNED_SC, DATUM_LEN_TAG>::Type DatumType;
+    // typedef typename ObEncodingTypeInference<IS_SIGNED_SC, DATUM_LEN_TAG>::Type DatumType;
     const StoreType *input = reinterpret_cast<const StoreType *>(base_data);
     int64_t tmp = input[row_ids[0]];
     for (int64_t i = 1; i < row_cap; i++) {
@@ -215,11 +215,12 @@ struct RawFixIntGetMinMaxFunc_T
         tmp = input[row_id];
       }
     }
-    *reinterpret_cast<DatumType *>(const_cast<char *>(datum.ptr_)) = tmp;
-    datum.pack_ = sizeof(DatumType);
+    datum.set_int(tmp);
+    // *reinterpret_cast<DatumType *>(const_cast<char *>(datum.ptr_)) = tmp;
+    // datum.pack_ = sizeof(DatumType);
   }
 };
-//Fast Min/Max for UIntSC / IntSC
+
  
 
 // Initialize fast int get min or max func family while compiling
@@ -774,7 +775,9 @@ bool ObRawDecoder::fast_agg_valid(const ObColumnDecoderCtx &ctx) const
     valid = !col_header->is_bit_packing()
         && !col_header->has_extend_value()
         && ((ObIntSC == store_class || ObUIntSC == store_class))
-        && raw_fix_batch_decode_funcs_inited;
+        && raw_fix_batch_decode_funcs_inited
+        && ctx.obj_meta_.get_type_class() != ObFloatTC
+        && ctx.obj_meta_.get_type_class() != ObDoubleTC;
     if (valid) {
       uint32_t store_size = col_header->length_;
       valid = (store_size == 1 || store_size == 2 || store_size == 4 || store_size == 8);

--- a/src/storage/blocksstable/encoding/ob_raw_decoder.h
+++ b/src/storage/blocksstable/encoding/ob_raw_decoder.h
@@ -52,12 +52,11 @@ typedef void (*fix_filter_func)(
             sql::ObBitVector &res);
 
 typedef void (*raw_fix_int_get_min_or_max_func)(
-            const int64_t col_len,
             const char *base_data,
             const int64_t *row_ids,
             const int64_t row_cap,
             bool is_min,
-            ObDatum &datum);
+            ObDatum &datum);        
 class ObRawDecoder : public ObIColumnDecoder
 {
 public:

--- a/src/storage/blocksstable/encoding/ob_raw_decoder.h
+++ b/src/storage/blocksstable/encoding/ob_raw_decoder.h
@@ -122,7 +122,6 @@ public:
 
   virtual int get_aggregate_result(
       const ObColumnDecoderCtx &ctx,
-      const ObIRowIndex *row_index,
       const int64_t *row_ids,
       const int64_t row_cap,
       ObMicroBlockAggInfo<ObDatum> &agg_info,

--- a/src/storage/blocksstable/encoding/ob_raw_decoder.h
+++ b/src/storage/blocksstable/encoding/ob_raw_decoder.h
@@ -51,6 +51,13 @@ typedef void (*fix_filter_func)(
             const uint64_t node_value,
             sql::ObBitVector &res);
 
+typedef void (*raw_fix_int_get_min_or_max_func)(
+            const int64_t col_len,
+            const char *base_data,
+            const int64_t *row_ids,
+            const int64_t row_cap,
+            bool is_min,
+            ObDatum &datum);
 class ObRawDecoder : public ObIColumnDecoder
 {
 public:
@@ -112,9 +119,18 @@ public:
       const int64_t *row_ids,
       const int64_t row_cap,
       int64_t &null_count) const override;
+
+  virtual int get_aggregate_result(
+      const ObColumnDecoderCtx &ctx,
+      const ObIRowIndex *row_index,
+      const int64_t *row_ids,
+      const int64_t row_cap,
+      ObMicroBlockAggInfo<ObDatum> &agg_info,
+      ObDatum *datum_buf) const override;
 private:
   bool fast_decode_valid(const ObColumnDecoderCtx &ctx) const;
 
+  bool fast_agg_valid(const ObColumnDecoderCtx &ctx) const;
   bool fast_filter_valid(
       const ObColumnDecoderCtx &ctx,
       const ObObjType &filter_value_type,

--- a/src/storage/blocksstable/encoding/ob_rle_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_rle_decoder.cpp
@@ -132,7 +132,9 @@ int ObRLEDecoder::get_aggregate_result(
   const int64_t dict_meta_length = ctx.col_header_->length_ - meta_header_->offset_;
   if (dict_count > 0) {
     if(row_cap == ctx.micro_block_header_->row_count_){
-      dict_decoder_.get_aggregate_result(ctx, row_ids, row_cap, agg_info, datum_buf);
+      if(OB_FAIL(dict_decoder_.get_aggregate_result(ctx, row_ids, row_cap, agg_info, datum_buf))){
+        LOG_WARN("failed to decode whole dict_decoder in rle", K(ret), K(dict_decoder_));
+      }
     } else {
       const ObIntArrayFuncTable &row_id_array
           = ObIntArrayFuncTable::instance(meta_header_->row_id_byte_);

--- a/src/storage/blocksstable/encoding/ob_rle_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_rle_decoder.cpp
@@ -122,13 +122,11 @@ int ObRLEDecoder::get_null_count(
 
 int ObRLEDecoder::get_aggregate_result(
     const ObColumnDecoderCtx &ctx,
-    const ObIRowIndex *row_index,
     const int64_t *row_ids,
     const int64_t row_cap,
     ObMicroBlockAggInfo<ObDatum> &agg_info,
     ObDatum *datum_buf) const
 {
-  UNUSEDx(row_index);
   int ret = OB_SUCCESS;
   const int64_t dict_count = dict_decoder_.get_dict_header()->count_;
   const int64_t dict_meta_length = ctx.col_header_->length_ - meta_header_->offset_;
@@ -139,7 +137,7 @@ int ObRLEDecoder::get_aggregate_result(
       int64_t i =0;
       while (OB_SUCC(ret) && traverse_it != end_it) {
         if (OB_FAIL(datum_buf[i].from_obj(*traverse_it))){
-          LOG_WARN("Failed to trans to datum");
+          LOG_WARN("Failed to trans to datum",K(ret),K(*traverse_it));
         } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
           LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
         }
@@ -168,7 +166,7 @@ int ObRLEDecoder::get_aggregate_result(
       int64_t trav_idx = monotonic_inc ? 0 : row_cap - 1;
       int64_t trav_cnt = 0;
       ObDictDecoderIterator begin_it = dict_decoder_.begin(&ctx, dict_meta_length);
-      while (trav_cnt < row_cap) {
+      while (OB_SUCC(ret) && trav_cnt < row_cap) {
         row_id = row_ids[trav_idx];
         if (ref_table_pos == ref_count || row_id < next_ref_row_id) {
         } else if (row_id == next_ref_row_id) {
@@ -179,7 +177,7 @@ int ObRLEDecoder::get_aggregate_result(
           curr_ref = ref_array.at_(meta_header_->payload_ + ref_offset_, ref_table_pos - 1);
           cell = *(begin_it + curr_ref);
           if (OB_FAIL(datum_buf[trav_cnt].from_obj(cell))){
-            LOG_WARN("Failed to trans to datum");
+            LOG_WARN("Failed to trans to datum",K(ret),K(cell));
           } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[trav_cnt]))){
             LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[trav_cnt]), K(agg_info));
           }
@@ -192,7 +190,7 @@ int ObRLEDecoder::get_aggregate_result(
           curr_ref = ref_array.at_(meta_header_->payload_ + ref_offset_, ref_table_pos - 1);
           cell = *(begin_it + curr_ref);
           if (OB_FAIL(datum_buf[trav_cnt].from_obj(cell))){
-            LOG_WARN("Failed to trans to datum");
+            LOG_WARN("Failed to trans to datum",K(ret),K(cell));
           } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[trav_cnt]))){
             LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[trav_cnt]), K(agg_info));
           }

--- a/src/storage/blocksstable/encoding/ob_rle_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_rle_decoder.cpp
@@ -120,6 +120,90 @@ int ObRLEDecoder::get_null_count(
   return ret;
 }
 
+int ObRLEDecoder::get_aggregate_result(
+    const ObColumnDecoderCtx &ctx,
+    const ObIRowIndex *row_index,
+    const int64_t *row_ids,
+    const int64_t row_cap,
+    ObMicroBlockAggInfo<ObDatum> &agg_info,
+    ObDatum *datum_buf) const
+{
+  UNUSEDx(row_index);
+  int ret = OB_SUCCESS;
+  const int64_t dict_count = dict_decoder_.get_dict_header()->count_;
+  const int64_t dict_meta_length = ctx.col_header_->length_ - meta_header_->offset_;
+  if (dict_count > 0) {
+    if(row_cap == ctx.micro_block_header_->row_count_){
+      ObDictDecoderIterator traverse_it = dict_decoder_.begin(&ctx, dict_meta_length);
+      ObDictDecoderIterator end_it = dict_decoder_.end(&ctx, dict_meta_length);
+      int64_t i =0;
+      while (OB_SUCC(ret) && traverse_it != end_it) {
+        if (OB_FAIL(datum_buf[i].from_obj(*traverse_it))){
+          LOG_WARN("Failed to trans to datum");
+        } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[i]))){
+          LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[i]), K(agg_info));
+        }
+        ++traverse_it;
+        ++i;
+      }
+    } else {
+      const ObIntArrayFuncTable &row_id_array
+          = ObIntArrayFuncTable::instance(meta_header_->row_id_byte_);
+      const ObIntArrayFuncTable &ref_array
+          = ObIntArrayFuncTable::instance(meta_header_->ref_byte_);
+      const int64_t ref_count = meta_header_->count_;
+
+      common::ObObj cell;
+      // Generate dict refs with minimum binary search call
+      int64_t row_id = 0;
+      int64_t ref_table_pos = 0;
+      int64_t next_ref_row_id = row_id_array.at_(meta_header_->payload_, ref_table_pos);
+      int64_t curr_ref = ref_array.at_(meta_header_->payload_ + ref_offset_, ref_table_pos);
+      // Traverse @row_ids by direction that row_id is monotonically increasing
+      bool monotonic_inc = true;
+      if (row_cap > 1) {
+        monotonic_inc = row_ids[1] > row_ids[0];
+      }
+      int64_t step = monotonic_inc ? 1 : -1;
+      int64_t trav_idx = monotonic_inc ? 0 : row_cap - 1;
+      int64_t trav_cnt = 0;
+      ObDictDecoderIterator begin_it = dict_decoder_.begin(&ctx, dict_meta_length);
+      while (trav_cnt < row_cap) {
+        row_id = row_ids[trav_idx];
+        if (ref_table_pos == ref_count || row_id < next_ref_row_id) {
+        } else if (row_id == next_ref_row_id) {
+          ++ref_table_pos;
+          if (ref_table_pos < ref_count) {
+            next_ref_row_id = row_id_array.at_(meta_header_->payload_, ref_table_pos);
+          }
+          curr_ref = ref_array.at_(meta_header_->payload_ + ref_offset_, ref_table_pos - 1);
+          cell = *(begin_it + curr_ref);
+          if (OB_FAIL(datum_buf[trav_cnt].from_obj(cell))){
+            LOG_WARN("Failed to trans to datum");
+          } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[trav_cnt]))){
+            LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[trav_cnt]), K(agg_info));
+          }
+        } else {
+          ref_table_pos =
+              row_id_array.upper_bound_(meta_header_->payload_, 0, ref_count, row_id);
+          if (ref_table_pos < ref_count) {
+            next_ref_row_id = row_id_array.at_(meta_header_->payload_, ref_table_pos);
+          }
+          curr_ref = ref_array.at_(meta_header_->payload_ + ref_offset_, ref_table_pos - 1);
+          cell = *(begin_it + curr_ref);
+          if (OB_FAIL(datum_buf[trav_cnt].from_obj(cell))){
+            LOG_WARN("Failed to trans to datum");
+          } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[trav_cnt]))){
+            LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[trav_cnt]), K(agg_info));
+          }
+        }
+        ++trav_cnt;
+        trav_idx += step;
+      }
+    }
+  }
+  return ret;
+}
 int ObRLEDecoder::pushdown_operator(
     const sql::ObPushdownFilterExecutor *parent,
     const ObColumnDecoderCtx &col_ctx,

--- a/src/storage/blocksstable/encoding/ob_rle_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_rle_decoder.cpp
@@ -173,10 +173,8 @@ int ObRLEDecoder::get_aggregate_result(
           curr_ref = ref_array.at_(meta_header_->payload_ + ref_offset_, ref_table_pos - 1);
           if (OB_FAIL(dict_decoder_.decode(ctx.obj_meta_, cell, curr_ref, dict_meta_length))) {
             LOG_WARN("failed to decode dict", K(ret), K(curr_ref));
-          } else if (OB_FAIL(datum_buf[trav_cnt].from_obj(cell))){
-            LOG_WARN("Failed to trans to datum",K(ret),K(cell));
-          } else if (OB_FAIL(agg_info.update_min_or_max(datum_buf[trav_cnt]))){
-            LOG_WARN("Failed to update_min_or_max", K(ret), K(datum_buf[trav_cnt]), K(agg_info));
+          } else if(OB_FAIL(ObIColumnDecoder::update_agg_from_obj(cell, agg_info, datum_buf[trav_cnt]))){
+            LOG_WARN("Failed to update_min_or_max");
           }
         }
         ++trav_cnt;

--- a/src/storage/blocksstable/encoding/ob_rle_decoder.h
+++ b/src/storage/blocksstable/encoding/ob_rle_decoder.h
@@ -63,7 +63,6 @@ public:
 
   virtual int get_aggregate_result(
       const ObColumnDecoderCtx &ctx,
-      const ObIRowIndex *row_index,
       const int64_t *row_ids,
       const int64_t row_cap,
       ObMicroBlockAggInfo<ObDatum> &agg_info,

--- a/src/storage/blocksstable/encoding/ob_rle_decoder.h
+++ b/src/storage/blocksstable/encoding/ob_rle_decoder.h
@@ -61,6 +61,14 @@ public:
       const int64_t row_cap,
       int64_t &null_count) const override;
 
+  virtual int get_aggregate_result(
+      const ObColumnDecoderCtx &ctx,
+      const ObIRowIndex *row_index,
+      const int64_t *row_ids,
+      const int64_t row_cap,
+      ObMicroBlockAggInfo<ObDatum> &agg_info,
+      ObDatum *datum_buf) const override;
+
   virtual int update_pointer(const char *old_block, const char *cur_block) override;
 
   void reset() { this->~ObRLEDecoder(); new (this) ObRLEDecoder(); }

--- a/src/storage/blocksstable/ob_imicro_block_reader.h
+++ b/src/storage/blocksstable/ob_imicro_block_reader.h
@@ -72,6 +72,8 @@ public:
     }
     return ret;
   }
+
+  bool get_is_min(){return is_min_;}
   TO_STRING_KV(K_(is_min), K_(cmp_fun), K_(result_datum));
 private:
   bool is_min_;

--- a/unittest/storage/blocksstable/encoding/test_column_decoder.h
+++ b/unittest/storage/blocksstable/encoding/test_column_decoder.h
@@ -1034,7 +1034,7 @@ void TestColumnDecoder::agg_min_or_max_test()
     ASSERT_EQ(OB_SUCCESS, encoder_.append_row(row)) << "i: " << i << std::endl;
   }
   for (int64_t i = ROW_CNT - 2; i < ROW_CNT; ++i) {
-    ASSERT_EQ(OB_SUCCESS, row_generate_.get_next_row(seed0, row));
+    ASSERT_EQ(OB_SUCCESS, row_generate_.get_next_row(seed1, row));
     ASSERT_EQ(OB_SUCCESS, encoder_.append_row(row)) << "i: " << i << std::endl;
   }
 
@@ -1079,7 +1079,7 @@ void TestColumnDecoder::agg_min_or_max_test()
     LOG_INFO("Current col: ", K(i), K(col_descs_.at(i).col_id_),  
         K(*decoder.decoders_[col_offset].ctx_),K(datums->len_));
     int64_t start_time = ObTimeUtility::current_time();
-    ASSERT_EQ(OB_SUCCESS, decoder.get_min_or_max(i , row_ids, cell_datas, ROW_CNT-1, datums, agg_info));    
+    ASSERT_EQ(OB_SUCCESS, decoder.get_min_or_max(i , row_ids, cell_datas, ROW_CNT, datums, agg_info));    
     int64_t end_time = ObTimeUtility::current_time();
     STORAGE_LOG(INFO,"get min/max time_new:",K(end_time-start_time),K(agg_info.result_datum_));
     sum_time_n += (end_time-start_time);
@@ -1111,9 +1111,9 @@ void TestColumnDecoder::agg_min_or_max_test()
     ASSERT_EQ(OB_SUCCESS, decoder.decoders_[col_offset].batch_decode(decoder.row_index_,
                             row_ids,
                             cell_datas,
-                            ROW_CNT-1,
+                            ROW_CNT,
                             datums));
-    for(int i = 0;i<ROW_CNT-1;++i){
+    for(int i = 0;i<ROW_CNT;++i){
       agg_info.update_min_or_max(datums[i]);
     } 
     int64_t end_time = ObTimeUtility::current_time();

--- a/unittest/storage/blocksstable/encoding/test_column_decoder.h
+++ b/unittest/storage/blocksstable/encoding/test_column_decoder.h
@@ -48,7 +48,7 @@ public:
   static const int64_t ROWKEY_CNT = 1;
   int64_t COLUMN_CNT = ObExtendType - 1 + 7;
 
-  static const int64_t ROW_CNT = 256;
+  static const int64_t ROW_CNT = 64;
 
   virtual void SetUp();
   virtual void TearDown();

--- a/unittest/storage/blocksstable/encoding/test_column_decoder.h
+++ b/unittest/storage/blocksstable/encoding/test_column_decoder.h
@@ -1032,17 +1032,16 @@ void TestColumnDecoder::agg_min_or_max_test(bool is_min,bool is_full_block)
     ASSERT_EQ(OB_SUCCESS, row_generate_.get_next_row(seed0, row));
     ASSERT_EQ(OB_SUCCESS, encoder_.append_row(row)) << "i: " << i << std::endl;
   }
-  for (int64_t i = ROW_CNT - 2; i < ROW_CNT; ++i) {
-    ASSERT_EQ(OB_SUCCESS, row_generate_.get_next_row(seed0, row));
+  for (int64_t i = ROW_CNT - 2; i < ROW_CNT-1; ++i) {
+    ASSERT_EQ(OB_SUCCESS, row_generate_.get_next_row(seed1, row));
     ASSERT_EQ(OB_SUCCESS, encoder_.append_row(row)) << "i: " << i << std::endl;
   }
-
-  // // for (int64_t j = 0; j < full_column_cnt_; ++j) {
-  // //   row.storage_datums_[j].set_null();
-  // // }
-  // // for (int64_t i = ROW_CNT - 1; i < ROW_CNT; ++i) {
-  // //   ASSERT_EQ(OB_SUCCESS, encoder_.append_row(row)) << "i: " << i << std::endl;
-  // // }
+  for (int64_t j = 0; j < full_column_cnt_; ++j) {
+    row.storage_datums_[j].set_null();
+  }
+  for (int64_t i = ROW_CNT - 1; i < ROW_CNT; ++i) {
+    ASSERT_EQ(OB_SUCCESS, encoder_.append_row(row)) << "i: " << i << std::endl;
+  }
   char *buf = NULL;
   int64_t size = 0;
   ASSERT_EQ(OB_SUCCESS, encoder_.build_block(buf, size));

--- a/unittest/storage/blocksstable/encoding/test_column_decoder.h
+++ b/unittest/storage/blocksstable/encoding/test_column_decoder.h
@@ -21,12 +21,15 @@
 #define private public
 #include "storage/blocksstable/encoding/ob_micro_block_encoder.h"
 #include "storage/blocksstable/encoding/ob_micro_block_decoder.h"
+#include "storage/blocksstable/ob_imicro_block_reader.h"
+#include "storage/access/ob_aggregated_store.h"
 #include "storage/blocksstable/ob_row_writer.h"
 #include "storage/access/ob_block_row_store.h"
 #include "storage/ob_i_store.h"
 #include "sql/engine/ob_exec_context.h"
 #include "sql/engine/basic/ob_pushdown_filter.h"
 #include "lib/string/ob_sql_string.h"
+#include "lib/time/ob_time_utility.h"
 #include "../ob_row_generate.h"
 #include "common/rowkey/ob_rowkey.h"
 #include "unittest/storage/mock_ob_table_read_info.h"
@@ -90,6 +93,8 @@ public:
   void batch_decode_to_datum_test(bool is_condensed = false);
 
   void batch_get_row_perf_test();
+
+  void agg_min_or_max_test();
 
   void set_encoding_type(ObColumnHeader::Type type);
 
@@ -1017,7 +1022,69 @@ void TestColumnDecoder::batch_decode_to_datum_test(bool is_condensed)
 //   std::cout << "Batch decode by column cost time: " << batch_end_time - batch_start_time << std::endl;
 // }
 
+void TestColumnDecoder::agg_min_or_max_test()
+{
+  ObDatumRow row;
+  ASSERT_EQ(OB_SUCCESS, row.init(allocator_, full_column_cnt_));
 
+  int64_t seed0 = 10000;
+  int64_t seed1 = 10001;
+  for (int64_t i = 0; i < ROW_CNT-2; ++i) {
+    ASSERT_EQ(OB_SUCCESS, row_generate_.get_next_row(seed0, row));
+    ASSERT_EQ(OB_SUCCESS, encoder_.append_row(row)) << "i: " << i << std::endl;
+  }
+  for (int64_t i = ROW_CNT - 2; i < ROW_CNT; ++i) {
+    ASSERT_EQ(OB_SUCCESS, row_generate_.get_next_row(seed1, row));
+    ASSERT_EQ(OB_SUCCESS, encoder_.append_row(row)) << "i: " << i << std::endl;
+  }
+
+  // for (int64_t j = 0; j < full_column_cnt_; ++j) {
+  //   row.storage_datums_[j].set_null();
+  // }
+  // for (int64_t i = ROW_CNT - 1; i < ROW_CNT; ++i) {
+  //   ASSERT_EQ(OB_SUCCESS, encoder_.append_row(row)) << "i: " << i << std::endl;
+  // }
+  char *buf = NULL;
+  int64_t size = 0;
+  ASSERT_EQ(OB_SUCCESS, encoder_.build_block(buf, size));
+  ObMicroBlockDecoder decoder;
+  ObMicroBlockData data(encoder_.get_data().data(), encoder_.get_data().pos());
+  ASSERT_EQ(OB_SUCCESS, decoder.init(data, read_info_));
+  const char *cell_datas[ROW_CNT];
+  void *datum_buf_1 = allocator_.alloc(sizeof(int8_t) * 128 * ROW_CNT);
+
+  int64_t sum_time_n = 0;
+  for (int64_t i = 0; i < full_column_cnt_; ++i) {
+    if (i >= rowkey_cnt_ && i < read_info_.get_rowkey_count()) {
+      continue;
+    }
+    int32_t col_offset = i;
+    ObDatum datums[ROW_CNT];
+    int64_t row_ids[ROW_CNT];
+    for (int64_t j = 0; j < ROW_CNT; ++j) {
+      datums[j].ptr_ = reinterpret_cast<char *>(datum_buf_1) + j * 128;
+      row_ids[j] = j;
+    }
+    ObStorageDatum result_datum;
+    result_datum.set_null();
+    ObObjType type = decoder.decoders_[col_offset].ctx_->obj_meta_.get_type();
+    ObDatumCmpFuncType cmp_fun = ObDatumFuncs::get_nullsafe_cmp_func(type,
+                                                      type,
+                                                      NULL_FIRST,
+                                                      decoder.decoders_[col_offset].ctx_->obj_meta_.get_collation_type(),
+                                                      SCALE_UNKNOWN_YET,
+                                                      false, false);
+    ObMicroBlockAggInfo<ObDatum> agg_info(true,cmp_fun,result_datum);
+    LOG_INFO("Current col: ", K(i), K(col_descs_.at(i).col_id_),  K(*decoder.decoders_[col_offset].ctx_),K(datums->len_));
+    int64_t start_time = ObTimeUtility::current_time();
+    ASSERT_EQ(OB_SUCCESS, decoder.get_min_or_max(i , row_ids, cell_datas, ROW_CNT, datums, agg_info));    
+    int64_t end_time = ObTimeUtility::current_time();
+    STORAGE_LOG(INFO,"get min/max time_new:",K(end_time-start_time),K(agg_info.result_datum_));
+    sum_time_n += (end_time-start_time);
+  }
+  double avg_time_n = sum_time_n*1.0/full_column_cnt_;
+  STORAGE_LOG(INFO,"get min/max time for all cols with decoder tpye:",K(decoder.col_header_->type_),K(avg_time_n));
+}
 
 } // end of namespace blocksstable
 } // end of namespace oceanbase

--- a/unittest/storage/blocksstable/encoding/test_const_decoder.cpp
+++ b/unittest/storage/blocksstable/encoding/test_const_decoder.cpp
@@ -641,10 +641,18 @@ TEST_F(TestConstDecoder, batch_decode_to_datum_test_without_expection)
   }
 }
 
+
+TEST_F(TestConstDecoder, get_min_or_max)
+{
+  agg_min_or_max_test();
+
+}
+
 TEST_F(TestConstDecoder, batch_decode_to_datum_test_with_expection)
 {
   batch_decode_to_datum_test();
 }
+
 
 // TEST_F(TestConstDecoder, batch_get_row_perf_test)
 // {

--- a/unittest/storage/blocksstable/encoding/test_const_decoder.cpp
+++ b/unittest/storage/blocksstable/encoding/test_const_decoder.cpp
@@ -642,16 +642,27 @@ TEST_F(TestConstDecoder, batch_decode_to_datum_test_without_expection)
 }
 
 
-TEST_F(TestConstDecoder, get_min_or_max)
+TEST_F(TestConstDecoder, get_min_or_max_test_tt)
 {
-  agg_min_or_max_test();
-
+  agg_min_or_max_test(true, true);
+}
+TEST_F(TestConstDecoder, get_min_or_max_test_ft)
+{
+  agg_min_or_max_test(false, true);
+}
+TEST_F(TestConstDecoder, get_min_or_max_test_tf)
+{
+  agg_min_or_max_test(true, false);
+}
+TEST_F(TestConstDecoder, get_min_or_max_test_ff)
+{
+  agg_min_or_max_test(false, false);
 }
 
-TEST_F(TestConstDecoder, batch_decode_to_datum_test_with_expection)
-{
-  batch_decode_to_datum_test();
-}
+// TEST_F(TestConstDecoder, batch_decode_to_datum_test_with_expection)
+// {
+//   batch_decode_to_datum_test();
+// }
 
 
 // TEST_F(TestConstDecoder, batch_get_row_perf_test)

--- a/unittest/storage/blocksstable/encoding/test_const_decoder.cpp
+++ b/unittest/storage/blocksstable/encoding/test_const_decoder.cpp
@@ -659,16 +659,16 @@ TEST_F(TestConstDecoder, get_min_or_max_test_ff)
   agg_min_or_max_test(false, false);
 }
 
-// TEST_F(TestConstDecoder, batch_decode_to_datum_test_with_expection)
-// {
-//   batch_decode_to_datum_test();
-// }
+TEST_F(TestConstDecoder, batch_decode_to_datum_test_with_expection)
+{
+  batch_decode_to_datum_test();
+}
 
 
-// TEST_F(TestConstDecoder, batch_get_row_perf_test)
-// {
-//   batch_get_row_perf_test();
-// }
+TEST_F(TestConstDecoder, batch_get_row_perf_test)
+{
+  batch_get_row_perf_test();
+}
 
 } // namespace blocksstable
 } // namespace oceanbase

--- a/unittest/storage/blocksstable/encoding/test_general_column_decoder.cpp
+++ b/unittest/storage/blocksstable/encoding/test_general_column_decoder.cpp
@@ -81,56 +81,70 @@ public:
   virtual ~TestStringPrefixDecoder() {}
 };
 
-TEST_F(TestIntBaseDiffDecoder, filter_pushdown_comaprison_neg_test)
+// TEST_F(TestIntBaseDiffDecoder, filter_pushdown_comaprison_neg_test)
+// {
+//   filter_pushdown_comaprison_neg_test();
+// }
+
+// PUSHDOWN_GENERAL_TEST(TestRetroPDDecoder);
+// PUSHDOWN_GENERAL_TEST(TestDictDecoder);
+// PUSHDOWN_GENERAL_TEST(TestRLEDecoder);
+// PUSHDOWN_GENERAL_TEST(TestIntBaseDiffDecoder);
+
+// TEST_F(TestHexDecoder, basic_filter_pushdown_op_test_eq_ne_nu_nn)
+// {
+//   basic_filter_pushdown_eq_ne_nu_nn_test();
+// }
+
+// TEST_F(TestDictDecoder, batch_decode_to_datum_condense_test)
+// {
+//   batch_decode_to_datum_test(true);
+// }
+
+// TEST_F(TestDictDecoder, batch_decode_to_datum_test)
+// {
+//   batch_decode_to_datum_test();
+// }
+
+// TEST_F(TestRLEDecoder, batch_decode_to_datum_test)
+// {
+//   batch_decode_to_datum_test();
+// }
+
+// TEST_F(TestIntBaseDiffDecoder, batch_decode_to_datum_test)
+// {
+//   batch_decode_to_datum_test();
+// }
+
+// TEST_F(TestHexDecoder, batch_decode_to_datum_test)
+// {
+//   batch_decode_to_datum_test();
+// }
+
+// TEST_F(TestStringDiffDecoder, batch_decode_to_datum_test)
+// {
+//   batch_decode_to_datum_test();
+// }
+
+// TEST_F(TestStringPrefixDecoder, batch_decode_to_datum_test)
+// {
+//   batch_decode_to_datum_test();
+// }
+
+TEST_F(TestDictDecoder, get_min_or_max_test)
 {
-  filter_pushdown_comaprison_neg_test();
+  agg_min_or_max_test();
 }
 
-PUSHDOWN_GENERAL_TEST(TestRetroPDDecoder);
-PUSHDOWN_GENERAL_TEST(TestDictDecoder);
-PUSHDOWN_GENERAL_TEST(TestRLEDecoder);
-PUSHDOWN_GENERAL_TEST(TestIntBaseDiffDecoder);
-
-TEST_F(TestHexDecoder, basic_filter_pushdown_op_test_eq_ne_nu_nn)
+TEST_F(TestRLEDecoder, get_min_or_max_test)
 {
-  basic_filter_pushdown_eq_ne_nu_nn_test();
+  agg_min_or_max_test();
 }
 
-TEST_F(TestDictDecoder, batch_decode_to_datum_condense_test)
+TEST_F(TestIntBaseDiffDecoder, get_min_or_max_test)
 {
-  batch_decode_to_datum_test(true);
+  agg_min_or_max_test();
 }
-
-TEST_F(TestDictDecoder, batch_decode_to_datum_test)
-{
-  batch_decode_to_datum_test();
-}
-
-TEST_F(TestRLEDecoder, batch_decode_to_datum_test)
-{
-  batch_decode_to_datum_test();
-}
-
-TEST_F(TestIntBaseDiffDecoder, batch_decode_to_datum_test)
-{
-  batch_decode_to_datum_test();
-}
-
-TEST_F(TestHexDecoder, batch_decode_to_datum_test)
-{
-  batch_decode_to_datum_test();
-}
-
-TEST_F(TestStringDiffDecoder, batch_decode_to_datum_test)
-{
-  batch_decode_to_datum_test();
-}
-
-TEST_F(TestStringPrefixDecoder, batch_decode_to_datum_test)
-{
-  batch_decode_to_datum_test();
-}
-
 // TEST_F(TestDictDecoder, batch_decode_perf_test)
 // {
 //   batch_get_row_perf_test();

--- a/unittest/storage/blocksstable/encoding/test_general_column_decoder.cpp
+++ b/unittest/storage/blocksstable/encoding/test_general_column_decoder.cpp
@@ -88,55 +88,55 @@ public:
   virtual ~TestStringPrefixDecoder() {}
 };
 
-// TEST_F(TestIntBaseDiffDecoder, filter_pushdown_comaprison_neg_test)
-// {
-//   filter_pushdown_comaprison_neg_test();
-// }
+TEST_F(TestIntBaseDiffDecoder, filter_pushdown_comaprison_neg_test)
+{
+  filter_pushdown_comaprison_neg_test();
+}
 
-// PUSHDOWN_GENERAL_TEST(TestRetroPDDecoder);
-// PUSHDOWN_GENERAL_TEST(TestDictDecoder);
-// PUSHDOWN_GENERAL_TEST(TestRLEDecoder);
-// PUSHDOWN_GENERAL_TEST(TestIntBaseDiffDecoder);
+PUSHDOWN_GENERAL_TEST(TestRetroPDDecoder);
+PUSHDOWN_GENERAL_TEST(TestDictDecoder);
+PUSHDOWN_GENERAL_TEST(TestRLEDecoder);
+PUSHDOWN_GENERAL_TEST(TestIntBaseDiffDecoder);
 
-// TEST_F(TestHexDecoder, basic_filter_pushdown_op_test_eq_ne_nu_nn)
-// {
-//   basic_filter_pushdown_eq_ne_nu_nn_test();
-// }
+TEST_F(TestHexDecoder, basic_filter_pushdown_op_test_eq_ne_nu_nn)
+{
+  basic_filter_pushdown_eq_ne_nu_nn_test();
+}
 
-// TEST_F(TestDictDecoder, batch_decode_to_datum_condense_test)
-// {
-//   batch_decode_to_datum_test(true);
-// }
+TEST_F(TestDictDecoder, batch_decode_to_datum_condense_test)
+{
+  batch_decode_to_datum_test(true);
+}
 
-// TEST_F(TestDictDecoder, batch_decode_to_datum_test)
-// {
-//   batch_decode_to_datum_test();
-// }
+TEST_F(TestDictDecoder, batch_decode_to_datum_test)
+{
+  batch_decode_to_datum_test();
+}
 
-// TEST_F(TestRLEDecoder, batch_decode_to_datum_test)
-// {
-//   batch_decode_to_datum_test();
-// }
+TEST_F(TestRLEDecoder, batch_decode_to_datum_test)
+{
+  batch_decode_to_datum_test();
+}
 
-// TEST_F(TestIntBaseDiffDecoder, batch_decode_to_datum_test)
-// {
-//   batch_decode_to_datum_test();
-// }
+TEST_F(TestIntBaseDiffDecoder, batch_decode_to_datum_test)
+{
+  batch_decode_to_datum_test();
+}
 
-// TEST_F(TestHexDecoder, batch_decode_to_datum_test)
-// {
-//   batch_decode_to_datum_test();
-// }
+TEST_F(TestHexDecoder, batch_decode_to_datum_test)
+{
+  batch_decode_to_datum_test();
+}
 
-// TEST_F(TestStringDiffDecoder, batch_decode_to_datum_test)
-// {
-//   batch_decode_to_datum_test();
-// }
+TEST_F(TestStringDiffDecoder, batch_decode_to_datum_test)
+{
+  batch_decode_to_datum_test();
+}
 
-// TEST_F(TestStringPrefixDecoder, batch_decode_to_datum_test)
-// {
-//   batch_decode_to_datum_test();
-// }
+TEST_F(TestStringPrefixDecoder, batch_decode_to_datum_test)
+{
+  batch_decode_to_datum_test();
+}
 
 TEST_F(TestDictDecoder, get_min_or_max_test_tt)
 {

--- a/unittest/storage/blocksstable/encoding/test_general_column_decoder.cpp
+++ b/unittest/storage/blocksstable/encoding/test_general_column_decoder.cpp
@@ -46,6 +46,13 @@ public:
   virtual ~TestRLEDecoder() {}
 };
 
+class TestConstDecoder : public TestColumnDecoder
+{
+public:
+  TestConstDecoder() : TestColumnDecoder(ObColumnHeader::Type::RLE) {}
+  virtual ~TestConstDecoder() {}
+};
+
 class TestIntBaseDiffDecoder : public TestColumnDecoder
 {
 public:
@@ -131,19 +138,55 @@ public:
 //   batch_decode_to_datum_test();
 // }
 
-TEST_F(TestDictDecoder, get_min_or_max_test)
+TEST_F(TestDictDecoder, get_min_or_max_test_tt)
 {
-  agg_min_or_max_test();
+  agg_min_or_max_test(true, true);
+}
+TEST_F(TestDictDecoder, get_min_or_max_test_ft)
+{
+  agg_min_or_max_test(false, true);
+}
+TEST_F(TestDictDecoder, get_min_or_max_test_tf)
+{
+  agg_min_or_max_test(true, false);
+}
+TEST_F(TestDictDecoder, get_min_or_max_test_ff)
+{
+  agg_min_or_max_test(false, false);
 }
 
-TEST_F(TestRLEDecoder, get_min_or_max_test)
+TEST_F(TestRLEDecoder, get_min_or_max_test_tt)
 {
-  agg_min_or_max_test();
+  agg_min_or_max_test(true, true);
+}
+TEST_F(TestRLEDecoder, get_min_or_max_test_ft)
+{
+  agg_min_or_max_test(false, true);
+}
+TEST_F(TestRLEDecoder, get_min_or_max_test_tf)
+{
+  agg_min_or_max_test(true, false);
+}
+TEST_F(TestRLEDecoder, get_min_or_max_test_ff)
+{
+  agg_min_or_max_test(false, false);
 }
 
-TEST_F(TestIntBaseDiffDecoder, get_min_or_max_test)
+TEST_F(TestIntBaseDiffDecoder, get_min_or_max_test_tt)
 {
-  agg_min_or_max_test();
+  agg_min_or_max_test(true, true);
+}
+TEST_F(TestIntBaseDiffDecoder, get_min_or_max_test_ft)
+{
+  agg_min_or_max_test(false, true);
+}
+TEST_F(TestIntBaseDiffDecoder, get_min_or_max_test_tf)
+{
+  agg_min_or_max_test(true, false);
+}
+TEST_F(TestIntBaseDiffDecoder, get_min_or_max_test_ff)
+{
+  agg_min_or_max_test(false, false);
 }
 // TEST_F(TestDictDecoder, batch_decode_perf_test)
 // {

--- a/unittest/storage/blocksstable/encoding/test_raw_decoder.cpp
+++ b/unittest/storage/blocksstable/encoding/test_raw_decoder.cpp
@@ -202,7 +202,7 @@ public:
 
   static const int64_t COLUMN_CNT = ObExtendType - 1 + 7;
 
-  static const int64_t ROW_CNT = 128;
+  static const int64_t ROW_CNT = 64;
 
   virtual void SetUp();
   virtual void TearDown() {}


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase**! 
Please read the [How to Contribute](https://github.com/oceanbase/oceanbase/wiki/how_to_contribute) document **BEFORE** filling this PR.

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description

<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->
ref #1487 .

### Solution Description

<!-- Please clearly and consice descipt the solution. -->

Add aggregate functions for RAW/DICT/RLE/CONST/INTER_DIFF decoders.
### Passed Regressions

<!-- Unittest, mysql test or test it manually? -->

Run Unittest for ObMicroBlockDecoder::get_min_or_max()  to check col_decoder.get_aggregate_result() .The following tables shows the speedup ratios before and after optimization in four different situations.  The ordinate represents the number of rows in the microblock. In order to fully test the supported data types, each column of the microblock has a different data type. 

### RAW
only optimized data with storage types of IntSC/UIntSC, only these data types were tested. 

### INTER_DIFF
only optimized for reading the entire microblock and taking out the min. 

### Unit test

### Value
the speedup ratio is calculated from the average time of 100 runs for all columns.

### Whole/Part
whole indicates that the whole microblock needs to be read, and part indicates that only part of the microblock within the row_cap range needs to be read.

RAW
ROWCNT | whole&part
-- | -- 
128 | 7.35
256 | 10.85
512 | 13.27

DICT
ROWCNT | whole | part
-- | -- | -- 
64 | 77.71 | 14.26
128 | 129.64  | 15.24 
256 | 293.84 | 16.79



RLE
ROWCNT | whole | part
-- | -- | -- 
64 | 31.86 | 30.25 
128 | 37.88 | 36.26
256 | 44.27 | 41.84



CONST
ROWCNT | whole | part
-- | -- | -- 
64 | 82.38 | 69.47 
128 | 161.51 | 111.57
256 | 355.81 | 196.77





INTER_DIFF
ROWCNT| whole&min
-- | -- 
64 | 18.33 
128 | 31.00 
256 | 53.00



### Data value examples of values used for different encodings.

Data value example for RAW/DICT/RLE/INTER_DIFF 
A | A | A | ... | A | B | B
-- | -- | -- | -- | -- | -- | --




Data value example for CONST
A | A | A | ... | A | A | A
-- | -- | -- | -- | -- | -- | --


### Mysql test

### Experimental environment
Since the optimization object is for the encoded data, all experiments are run after manually triggering the MAJOR FREEZE.

For hot and cold queries, the experimental results are the average time of multiple hot queries, which is the result of effectively using the cache.

### Data value example for mysql test
Data value  for DICT
A | B | C | A | B | C | ... | A | B | C 
-- | -- | -- | -- | -- | -- | -- | -- | -- | --


Data value  for RLE
A | ... | A | B | ... | B | C | ... | C | ... | A | ... | A | B | ... | B | C | ... | C
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- 

Data value for CONST
A | A | A | ... | A | A | A
-- | -- | -- | -- | -- | -- | -- 

Data value for INTER_DIFF 
10000000 | 10000001 | 10000002 | ... | 19999997 | 19999998 | 19999999
-- | -- | -- | -- | -- | -- | -- 

Data value for RAW
A | B | G | ... | F | L | K
-- | -- | -- | -- | -- | -- | -- 

### Result of mysql test

scan whole table
SQL:SELECT min(value) FROM table;

  |  data_type | int |  | number | |char|  | varchar | |
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- 
encoding_type | row_count | o_time(ms) | n_time(ms) | o_time(ms) | n_time(ms) | o_time(ms) | n_time(ms) | o_time(ms) | n_time(ms)
DICT | 6000000 | 618 | 30 | 686 | 30 | 911 | 31 | 977 | 31
CONST | 6000000 | 428 | 30 | 524 | 29 | 836 | 29 | 995 | 29
RLE | 6000000 | 541 | 30 | 589 | 31 | 829 | 34 | 965 | 32
INTER_DIFF(min) | 6000000 | 883 | 53 | / | / | / | / | / | /
RAW | 6000000 | 532 | 114 | / | / | / | / | / | /



scan part table with different filter rate
SQL:select min(v_num) from const where id <60000;

  |   | Filter range | 1.0% | | 10.0% | | 100.0%||
-- | -- | -- | -- | -- | -- | -- | -- | -- 
encoding_type | row_count | data_type | o_time(ms) | n_time(ms) | o_time(ms) | n_time(ms) | o_time(ms) | n_time(ms)
DICT | 6000000 | number | 10 | 4 | 72 | 6 | 680 | 26
CONST | 6000000 | number | 8 | 2 | 56 | 5 | 524 | 25
RLE | 6000000 | number | 9 | 3 | 64 | 5 | 586 | 26
INTER_DIFF(min) | 6000000 | int | 9 | 4 | 57 | 6 | 521 | 29
RAW | 6000000 | int | 9 | 4 | 57 | 16 | 521 | 113




