### PR TITLE
issue#1503: memtable scan optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,4 +178,6 @@ elseif (OB_INCLUDE_TOOLS)
   add_subdirectory(tools EXCLUDE_FROM_ALL)
 endif()
 
+add_subdirectory(mittest EXCLUDE_FROM_ALL)
+
 include(cmake/RPM.cmake)

--- a/mittest/mtlenv/storage/CMakeLists.txt
+++ b/mittest/mtlenv/storage/CMakeLists.txt
@@ -30,4 +30,4 @@ storage_dml_unittest(test_ls_tablet_info_writer_and_reader test_ls_tablet_info_w
 add_subdirectory(checkpoint)
 add_subdirectory(blocksstable)
 
-target_link_libraries(test_memtable PUBLIC mock_tx_ctx mock_tx_log_adapter)
+# target_link_libraries(test_memtable PUBLIC mock_tx_ctx mock_tx_log_adapter)

--- a/mittest/simple_server/CMakeLists.txt
+++ b/mittest/simple_server/CMakeLists.txt
@@ -96,6 +96,7 @@ ob_unittest_observer(test_transfer_lock_info_operator storage_ha/test_transfer_l
 ob_unittest_observer(test_mds_recover test_mds_recover.cpp)
 ob_unittest_observer(test_keep_alive_min_start_scn test_keep_alive_min_start_scn.cpp)
 ob_unittest_observer(test_ls_replica test_ls_replica.cpp)
+ob_unittest_observer(test_memtable_scan test_memtable_scan.cpp)
 # TODO(muwei.ym): open later
 #ob_ha_unittest_observer(test_transfer_handler storage_ha/test_transfer_handler.cpp)
 #ob_ha_unittest_observer(test_transfer_and_restart_basic storage_ha/test_transfer_and_restart_basic.cpp)

--- a/mittest/simple_server/test_memtable_scan.cpp
+++ b/mittest/simple_server/test_memtable_scan.cpp
@@ -1,0 +1,951 @@
+/**
+ * Copyright (c) 2021 OceanBase
+ * OceanBase CE is licensed under Mulan PubL v2.
+ * You can use this software according to the terms and conditions of the Mulan PubL v2.
+ * You may obtain a copy of Mulan PubL v2 at:
+ *          http://license.coscl.org.cn/MulanPubL-2.0
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PubL v2 for more details.
+ */
+
+#include <gtest/gtest.h>
+#define USING_LOG_PREFIX SERVER
+#define protected public
+#define private public
+
+#include "env/ob_simple_cluster_test_base.h"
+#include "lib/mysqlclient/ob_mysql_result.h"
+
+namespace oceanbase
+{
+namespace unittest
+{
+
+using namespace oceanbase::transaction;
+using namespace oceanbase::storage;
+
+#define WRITE_SQL_BY_CONN(conn, sql_str)      \
+  ASSERT_EQ(OB_SUCCESS, sql.assign(sql_str)); \
+  ASSERT_EQ(OB_SUCCESS, conn->execute_write(OB_SYS_TENANT_ID, sql.ptr(), affected_rows));
+
+#define WRITE_SQL_FMT_BY_CONN(conn, ...)              \
+  ASSERT_EQ(OB_SUCCESS, sql.assign_fmt(__VA_ARGS__)); \
+  ASSERT_EQ(OB_SUCCESS, conn->execute_write(OB_SYS_TENANT_ID, sql.ptr(), affected_rows));
+
+#define READ_SQL_BY_CONN(conn, sql_str)                                 \
+  ASSERT_EQ(OB_SUCCESS, sql.assign(sql_str));                           \
+  ASSERT_EQ(OB_SUCCESS, conn->execute_read(OB_SYS_TENANT_ID, sql.ptr(), read_res));
+
+#define READ_SQL_FMT_BY_CONN(conn, ...)                                 \
+  ASSERT_EQ(OB_SUCCESS, sql.assign_fmt(__VA_ARGS__));                   \
+  ASSERT_EQ(OB_SUCCESS, conn->execute_read(OB_SYS_TENANT_ID, sql.ptr(), read_res));
+
+#define DEF_VAL_FOR_SQL      \
+  int ret = OB_SUCCESS;      \
+  ObSqlString sql;           \
+  int64_t affected_rows = 0; \
+  sqlclient::ObISQLConnection *connection = nullptr;\
+  ObISQLClient::ReadResult read_res;\
+  sqlclient::ObMySQLResult *result;
+
+class TestRunCtx
+{
+public:
+  uint64_t tenant_id_ = 0;
+  int time_sec_ = 0;
+};
+
+TestRunCtx RunCtx;
+
+class ObTestMemtableScan : public ObSimpleClusterTestBase {
+public:
+  // 创建一个100G数据盘、15G内存的observer
+  ObTestMemtableScan() : ObSimpleClusterTestBase("test_memtable_scan_", "200G", "100G") {}
+
+  void minor_freeze_data_and_wait()
+  {
+    common::ObMySQLProxy &sql_proxy = get_curr_simple_server().get_sql_proxy();
+    sqlclient::ObISQLConnection *connection = nullptr;
+    ASSERT_EQ(OB_SUCCESS, sql_proxy.acquire(connection));
+
+    int ret = OB_SUCCESS;
+    ObSqlString sql;
+    int64_t affected_rows = 0;
+
+    WRITE_SQL_BY_CONN(connection, "alter system minor freeze tenant all;");
+    fprintf(stdout, "start flush user data\n");
+    sleep(10);
+
+    int retry_times = 0;
+    bool freeze_success = false;
+    HEAP_VAR(ObMySQLProxy::MySQLResult, res)
+    {
+      int64_t cnt = -1;
+      while (++retry_times <= 600) {
+        ASSERT_EQ(OB_SUCCESS,
+                  connection->execute_read(OB_SYS_TENANT_ID,
+                                           "select count(*) as cnt from oceanbase.__all_virtual_table_mgr where "
+                                           "table_type=0 and is_active like '%NO%';",
+                                           res));
+        common::sqlclient::ObMySQLResult *result = res.mysql_result();
+        ASSERT_EQ(OB_SUCCESS, result->next());
+        ASSERT_EQ(OB_SUCCESS, result->get_int("cnt", cnt));
+        if (0 == cnt) {
+          freeze_success = true;
+          break;
+        }
+      }
+      fprintf(stdout,  "waitting for data minor merge. retry times = %d\n", retry_times);
+      sleep(1);
+    }
+
+    ASSERT_EQ(true, freeze_success);
+  }
+};
+
+TEST_F(ObTestMemtableScan, observer_start)
+{
+  SERVER_LOG(INFO, "observer_start succ");
+}
+
+TEST_F(ObTestMemtableScan, add_tenant)
+{
+  // 创建普通租户tt1，使用大内存
+  ASSERT_EQ(OB_SUCCESS, create_tenant("tt1", "10G", "50G", false));
+  // 获取租户tt1的tenant_id
+  ASSERT_EQ(OB_SUCCESS, get_tenant_id(RunCtx.tenant_id_));
+  ASSERT_NE(0, RunCtx.tenant_id_);
+  // 初始化普通租户tt1的sql proxy
+  ASSERT_EQ(OB_SUCCESS, get_curr_simple_server().init_sql_proxy2());
+
+  DEF_VAL_FOR_SQL;
+  ASSERT_EQ(OB_SUCCESS, get_curr_simple_server().get_sql_proxy2().acquire(connection));
+  // 调大转储mini后触发minor merge的次数
+  WRITE_SQL_BY_CONN(connection, "ALTER SYSTEM SET minor_compact_trigger = 10;");
+  // 调大限速
+  WRITE_SQL_BY_CONN(connection, "ALTER SYSTEM SET writing_throttling_trigger_percentage = 100;");
+  sleep(2);
+  // 调大冻结阈值
+  WRITE_SQL_BY_CONN(connection, "ALTER SYSTEM SET freeze_trigger_percentage = 80;");
+  // 开启优化
+  WRITE_SQL_BY_CONN(connection, "alter system set memtable_scan_filter_pushdown = 1;");
+}
+
+// TEST_F(ObTestMemtableScan, multiple_scan_merge3)
+// {
+//   DEF_VAL_FOR_SQL;
+//   common::ObMySQLProxy &sql_proxy = get_curr_simple_server().get_sql_proxy2();
+//   ASSERT_EQ(OB_SUCCESS, sql_proxy.acquire(connection));
+
+//   // 调大超时时间
+//   WRITE_SQL_BY_CONN(connection, "SET SESSION OB_QUERY_TIMEOUT = 1000 * 1000 * 1000 * 1000;");
+//   WRITE_SQL_BY_CONN(connection, "SET SESSION OB_TRX_TIMEOUT = 1000 * 1000 * 1000 * 1000;");
+//   WRITE_SQL_BY_CONN(connection, "SET SESSION OB_TRX_IDLE_TIMEOUT = 1000 * 1000 * 1000 * 1000;");
+//   sleep(5);
+
+//   // 建表
+//   WRITE_SQL_BY_CONN(
+//       connection,
+//       "CREATE TABLE test.multiple_scan_merge3 (c1 BIGINT PRIMARY KEY, c2 BIGINT, c3 BIGINT, c4 BIGINT, c5 BIGINT, c6 BIGINT, c7 BIGINT);")
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m3s0 START WITH 0 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 300 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m3s1 START WITH 1 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 300 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m3s2 START WITH 2 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 300 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m3s3 START WITH 3 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 300 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m3s4 START WITH 0 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 1 CACHE 10000000 ORDER;");
+
+//   // 循环 4 次，每次写 1000 行，产生 4 个 mini sstable
+//   char sql_str[1024] = "";
+//   for (int64_t i = 0; i < 4; i++) {
+//     WRITE_SQL_FMT_BY_CONN(connection,
+//                           "INSERT INTO                                "
+//                           "       test.multiple_scan_merge3           "
+//                           "SELECT                                     "
+//                           "       m3s%ld.nextval c1,                  "
+//                           "       uniform(1, 1000, random()) c2,      "
+//                           "       uniform(1, 1000, random()) c3,      "
+//                           "       uniform(1, 1000, random()) c4,      "
+//                           "       uniform(1, 1000, random()) c5,      "
+//                           "       uniform(1, 1000, random()) c6,      "
+//                           "       uniform(1, 1000, random()) c7       "
+//                           "FROM                                       "
+//                           "       table(generator(1000));             ", i);
+//     fprintf(stdout, "do minor freeze once. freeze count : %ld\n", i+1);
+//     minor_freeze_data_and_wait();
+//   }
+
+//   // 写 100000 行数据到 memtable
+//   WRITE_SQL_BY_CONN(connection,
+//                     "INSERT IGNORE INTO                         "
+//                     "       test.multiple_scan_merge3           "
+//                     "SELECT                                     "
+//                     "       m3s4.nextval c1,                    "
+//                     "       uniform(1, 1000, random()) c2,      "
+//                     "       uniform(1, 1000, random()) c3,      "
+//                     "       uniform(1, 1000, random()) c4,      "
+//                     "       uniform(1, 1000, random()) c5,      "
+//                     "       uniform(1, 1000, random()) c6,      "
+//                     "       uniform(1, 1000, random()) c7       "
+//                     "FROM                                       "
+//                     "       table(generator(100000));           ");
+
+//   fprintf(stdout, "prepare data done, start time cost test ...\n");
+
+//   int64_t len1 = 0,len2 = 0, c1;
+//   clock_t start, end;
+
+//   start = clock();
+//   READ_SQL_BY_CONN(connection, "select c1, c2, c3 from test.multiple_scan_merge3 where (c1 < 100000) and (c2 < 700 and (c3 > 300 or (c4 * 2 < 1200 and (c5 + 100 > 200 or (c6 < 800 and c7 > 200))))); ");
+
+//   result = read_res.get_result();
+//   ASSERT_NE(nullptr, result);
+
+//   while (OB_SUCC(result->next())) {
+//     ASSERT_EQ(OB_SUCCESS, result->get_int("c1", c1));
+//     ++len1;
+//   }
+//   ASSERT_EQ(OB_ITER_END, ret);
+//   end = clock();
+
+//   fprintf(stdout, "get %ld result rows, use timem %f\n", len1, (double)(end - start) / CLOCKS_PER_SEC);
+
+//   WRITE_SQL_BY_CONN(connection, "alter system set memtable_scan_filter_pushdown = 0;");
+//   sleep(10);
+
+//   start = clock();
+//   READ_SQL_BY_CONN(connection, "select c1, c2, c3 from test.multiple_scan_merge3 where (c1 < 100000) and (c2 < 700 and (c3 > 300 or (c4 * 2 < 1200 and (c5 + 100 > 200 or (c6 < 800 and c7 > 200))))); ");
+
+//   result = read_res.get_result();
+//   ASSERT_NE(nullptr, result);
+
+//   while (OB_SUCC(result->next())) {
+//     ASSERT_EQ(OB_SUCCESS, result->get_int("c1", c1));
+//     ++len2;
+//   }
+//   ASSERT_EQ(OB_ITER_END, ret);
+//   end = clock();
+
+//   fprintf(stdout, "get %ld result rows, use timem %f\n", len2, (double)(end - start) / CLOCKS_PER_SEC);
+// }
+
+// 正确性验证，一种比较极端的情况，数据按 rowkey 先后分布在 4张 SSTable 与 MemTable 之上
+// 这种情况会触发单边扫描，但是单边扫描立刻就会结束；理论上这种情况应该是修改后性能最差的情况；
+// TEST_F(ObTestMemtableScan, multiple_scan_merge1)
+// {
+//   DEF_VAL_FOR_SQL;
+//   common::ObMySQLProxy &sql_proxy = get_curr_simple_server().get_sql_proxy2();
+//   ASSERT_EQ(OB_SUCCESS, sql_proxy.acquire(connection));
+//   // 调大超时时间
+//   WRITE_SQL_BY_CONN(connection, "SET GLOBAL OB_QUERY_TIMEOUT = 10 * 1000 * 1000 * 1000;");
+//   WRITE_SQL_BY_CONN(connection, "SET GLOBAL OB_TRX_TIMEOUT = 10 * 1000 * 1000 * 1000;");
+//   WRITE_SQL_BY_CONN(connection, "SET GLOBAL OB_TRX_IDLE_TIMEOUT = 10 * 1000 * 1000 * 1000;");
+
+//   // 建表
+//   WRITE_SQL_BY_CONN(
+//       connection,
+//       "CREATE TABLE test.multiple_scan_merge1 (c1 BIGINT PRIMARY KEY, c2 BIGINT, c3 BIGINT);")
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m1s0 START WITH 0 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 5 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m1s1 START WITH 1 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 5 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m1s2 START WITH 2 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 5 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m1s3 START WITH 3 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 5 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m1s4 START WITH 4 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 5 CACHE 10000000 ORDER;");
+
+//   // 循环 4 次，每次写 10000 行，产生 4 个 mini sstable
+//   char sql_str[1024] = "";
+//   for (int64_t i = 0; i < 4; i++) {
+//     WRITE_SQL_FMT_BY_CONN(connection,
+//                           "INSERT INTO                                "
+//                           "       test.multiple_scan_merge1           "
+//                           "SELECT                                     "
+//                           "       m1s%ld.nextval c1,                  "
+//                           "       random() %% 10000 c2,               "
+//                           "       zipf(1, 100, random(3)) c3          "
+//                           "FROM                                       "
+//                           "       table(generator(1000));            ", i);
+//     fprintf(stdout, "do minor freeze once. freeze count : %ld\n", i+1);
+//     minor_freeze_data_and_wait();
+//   }
+
+//   // 写 10000 行数据到 memtable
+//   WRITE_SQL_BY_CONN(connection,
+//                     "INSERT INTO                                "
+//                     "       test.multiple_scan_merge1           "
+//                     "SELECT                                     "
+//                     "       m1s4.nextval c1,                    "
+//                     "       random() % 10000000 c2,             "
+//                     "       zipf(1, 100, random(3)) c3          "
+//                     "FROM                                       "
+//                     "       table(generator(1000));            ");
+//   fprintf(stdout, "prepare data done, start test ...\n");
+//   // 从表中读取数据
+//   READ_SQL_FMT_BY_CONN(connection, "select c1, c2, c3 from test.multiple_scan_merge1;");
+//   result = read_res.get_result();
+//   ASSERT_NE(nullptr, result);
+
+//   int rowkey = 0;
+//   while (OB_SUCC(result->next())) {
+//     int64_t c1;
+//     ASSERT_EQ(OB_SUCCESS, result->get_int("c1", c1));
+//     ASSERT_EQ(c1, rowkey++);
+//   }
+//   ASSERT_EQ(OB_ITER_END, ret);
+// }
+
+// // 正确性测试，(0, 1, 2, 3) 分布在 4张 SSTable 之上；(4-9) 分布在 MemTable 之上；
+// // 会触发单边扫描，每个 batch 包含 5 条数据；
+// TEST_F(ObTestMemtableScan, multiple_scan_merge2)
+// {
+//   DEF_VAL_FOR_SQL;
+//   common::ObMySQLProxy &sql_proxy = get_curr_simple_server().get_sql_proxy2();
+//   ASSERT_EQ(OB_SUCCESS, sql_proxy.acquire(connection));
+
+//   // 建表
+//   WRITE_SQL_BY_CONN(
+//       connection,
+//       "CREATE TABLE test.multiple_scan_merge2 (c1 BIGINT PRIMARY KEY, c2 BIGINT, c3 BIGINT);")
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m2s0 START WITH 0 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 10 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m2s1 START WITH 1 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 10 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m2s2 START WITH 2 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 10 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m2s3 START WITH 3 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 10 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m2s4 START WITH 0 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 1 CACHE 10000000 ORDER;");
+
+//   // 循环 4 次，每次写 1000 行，产生 4 个 mini sstable
+//   char sql_str[1024] = "";
+//   for (int64_t i = 0; i < 4; i++) {
+//     WRITE_SQL_FMT_BY_CONN(connection,
+//                           "INSERT INTO                                "
+//                           "       test.multiple_scan_merge2           "
+//                           "SELECT                                     "
+//                           "       m2s%ld.nextval c1,                  "
+//                           "       random() %% 10000 c2,               "
+//                           "       zipf(1, 100, random(3)) c3         "
+//                           "FROM                                       "
+//                           "       table(generator(1000));             ", i);
+//     fprintf(stdout, "do minor freeze once. freeze count : %ld\n", i+1);
+//     minor_freeze_data_and_wait();
+//   }
+
+//   // 写 10010 行数据到 memtable
+//   WRITE_SQL_BY_CONN(connection,
+//                     "INSERT IGNORE INTO                         "
+//                     "       test.multiple_scan_merge2           "
+//                     "SELECT                                     "
+//                     "       m2s4.nextval c1,                    "
+//                     "       random() % 10000000 c2,             "
+//                     "       zipf(1, 100, random(3)) c3         "
+//                     "FROM                                       "
+//                     "       table(generator(10010));            ");
+//   // 从表中读取数据
+//   fprintf(stdout, "prepare data done, start test ...\n");
+//   // 从表中读取数据
+//   READ_SQL_FMT_BY_CONN(connection, "select c1, c2, c3 from test.multiple_scan_merge2 where c1 >= 100 order by c1");
+//   result = read_res.get_result();
+//   ASSERT_NE(nullptr, result);
+
+//   int rowkey = 100;
+//   while (OB_SUCC(result->next())) {
+//     int64_t c1;
+//     ASSERT_EQ(OB_SUCCESS, result->get_int("c1", c1));
+//     ASSERT_EQ(c1, rowkey++);
+//   }
+//   ASSERT_EQ(OB_ITER_END, ret);
+// }
+
+// TEST_F(ObTestMemtableScan, multiple_scan_merge3)
+// {
+//   DEF_VAL_FOR_SQL;
+//   common::ObMySQLProxy &sql_proxy = get_curr_simple_server().get_sql_proxy2();
+//   ASSERT_EQ(OB_SUCCESS, sql_proxy.acquire(connection));
+
+//   // 调大超时时间
+//   WRITE_SQL_BY_CONN(connection, "SET SESSION OB_QUERY_TIMEOUT = 1000 * 1000 * 1000 * 1000;");
+//   WRITE_SQL_BY_CONN(connection, "SET SESSION OB_TRX_TIMEOUT = 1000 * 1000 * 1000 * 1000;");
+//   WRITE_SQL_BY_CONN(connection, "SET SESSION OB_TRX_IDLE_TIMEOUT = 1000 * 1000 * 1000 * 1000;");
+//   sleep(5);
+
+//   // 建表
+//   WRITE_SQL_BY_CONN(
+//       connection,
+//       "CREATE TABLE test.multiple_scan_merge3 (c1 BIGINT PRIMARY KEY, c2 BIGINT, c3 BIGINT);")
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m3s0 START WITH 0 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 300 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m3s1 START WITH 1 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 300 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m3s2 START WITH 2 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 300 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m3s3 START WITH 3 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 300 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m3s4 START WITH 0 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 1 CACHE 10000000 ORDER;");
+
+//   // 循环 4 次，每次写 1000 行，产生 4 个 mini sstable
+//   char sql_str[1024] = "";
+//   for (int64_t i = 0; i < 4; i++) {
+//     WRITE_SQL_FMT_BY_CONN(connection,
+//                           "INSERT INTO                                "
+//                           "       test.multiple_scan_merge3           "
+//                           "SELECT                                     "
+//                           "       m3s%ld.nextval c1,                  "
+//                           "       uniform(1, 1000, random()) c2,      "
+//                           "       uniform(1, 1000, random()) c3       "
+//                           "FROM                                       "
+//                           "       table(generator(1000));             ", i);
+//     fprintf(stdout, "do minor freeze once. freeze count : %ld\n", i+1);
+//     minor_freeze_data_and_wait();
+//   }
+
+//   // 写 100000 行数据到 memtable
+//   WRITE_SQL_BY_CONN(connection,
+//                     "INSERT IGNORE INTO                         "
+//                     "       test.multiple_scan_merge3           "
+//                     "SELECT                                     "
+//                     "       m3s4.nextval c1,                    "
+//                     "       uniform(1, 1000, random()) c2,      "
+//                     "       uniform(1, 1000, random()) c3      "
+//                     "FROM                                       "
+//                     "       table(generator(10000));           ");
+
+//   fprintf(stdout, "prepare data done, start time cost test ...\n");
+
+//   READ_SQL_BY_CONN(connection, "select c1, c2, c3 from test.multiple_scan_merge3 where c1 < 10000;");
+
+//   result = read_res.get_result();
+//   ASSERT_NE(nullptr, result);
+
+//   int64_t rowkey = 0, c1;
+//   while (OB_SUCC(result->next())) {
+//     ASSERT_EQ(OB_SUCCESS, result->get_int("c1", c1));
+//     ASSERT_EQ(c1, rowkey++);
+//   }
+//   ASSERT_EQ(OB_ITER_END, ret);
+// }
+
+TEST_F(ObTestMemtableScan, correctness_with_filter)
+{
+  DEF_VAL_FOR_SQL;
+  ASSERT_EQ(OB_SUCCESS, get_curr_simple_server().get_sql_proxy2().acquire(connection));
+
+  WRITE_SQL_BY_CONN(connection, "ALTER SYSTEM SET minor_compact_trigger = 10;");
+  // 调大限速
+  WRITE_SQL_BY_CONN(connection, "ALTER SYSTEM SET writing_throttling_trigger_percentage = 100;");
+  // 调大冻结阈值
+  WRITE_SQL_BY_CONN(connection, "ALTER SYSTEM SET freeze_trigger_percentage = 80;");
+
+  // 调大超时时间
+  WRITE_SQL_BY_CONN(connection, "SET SESSION OB_QUERY_TIMEOUT = 1000 * 1000 * 1000 * 1000;");
+  WRITE_SQL_BY_CONN(connection, "SET SESSION OB_TRX_TIMEOUT = 1000 * 1000 * 1000 * 1000;");
+  WRITE_SQL_BY_CONN(connection, "SET SESSION OB_TRX_IDLE_TIMEOUT = 1000 * 1000 * 1000 * 1000;");
+
+  sleep(10);
+
+  // 建表
+  WRITE_SQL_BY_CONN(
+      connection,
+      "CREATE TABLE test.memtable_scan_with_filter (c1 BIGINT PRIMARY KEY, c2 INT, c3 MEDIUMINT);")
+
+  // 循环五次，每次写一万行，产生5个mini sstable
+  for (int64_t i = 0; i < 5; i++) {
+    WRITE_SQL_BY_CONN(connection,
+                      "INSERT IGNORE INTO                         "
+                      "       test.memtable_scan_with_filter      "
+                      "SELECT                                     "
+                      "       uniform(1, 300000, random()) c1,    "
+                      "       random() % 10000 c2,                "
+                      "       zipf(1, 100, random(3)) c3          "
+                      "FROM                                       "
+                      "       table(generator(10000));            ");
+    fprintf(stdout, "do minor freeze once. freeze count : %ld\n", i+1);
+    minor_freeze_data_and_wait();
+  }
+
+  // 写10万行数据到memtable
+  WRITE_SQL_BY_CONN(connection,
+                    "INSERT IGNORE INTO                         "
+                    "       test.memtable_scan_with_filter      "
+                    "SELECT                                     "
+                    "       uniform(1, 300000, random()) c1,    "
+                    "       uniform(1, 1000, random()) c2,      "
+                    "       uniform(1, 1000, random()) c3       "
+                    "FROM                                       "
+                    "       table(generator(100000));           ");
+  fprintf(stdout, "prepare data done, start test ...\n");
+
+  int64_t len1, len2, para1, para2, para3;
+  int64_t result_y[2][10000];
+  int64_t result_n[2][10000];
+  for (int ntest = 0; ntest < 30; ++ntest) {
+    len1 = len2 = 0;
+    para1 = rand() % 300000;
+    para2 = rand() % 1000;
+    para3 = rand() % 1000;
+
+    WRITE_SQL_BY_CONN(connection, "alter system set memtable_scan_filter_pushdown = 1;");
+    sleep(10);
+    READ_SQL_FMT_BY_CONN(connection, "select c1, c2 from memtable_scan_with_filter where c1 > %ld and c1 < %ld and "
+                                     "c2 > %ld and c3 < %ld", para1, para1 + 10000, para2, para3);
+
+    result = read_res.get_result();
+    ASSERT_NE(nullptr, result);
+
+    while (OB_SUCC(result->next())) {
+      ASSERT_EQ(OB_SUCCESS, result->get_int("c1", result_y[0][len1]));
+      ASSERT_EQ(OB_SUCCESS, result->get_int("c2", result_y[1][len1]));
+      ++len1;
+    }
+    ASSERT_EQ(OB_ITER_END, ret);
+
+    WRITE_SQL_BY_CONN(connection, "alter system set memtable_scan_filter_pushdown = 0;");
+    sleep(10);
+    READ_SQL_FMT_BY_CONN(connection, "select c1, c2 from memtable_scan_with_filter where c1 > %ld and c1 < %ld and "
+                                     "c2 > %ld and c3 < %ld", para1, para1 + 10000, para2, para3);
+
+    result = read_res.get_result();
+    ASSERT_NE(nullptr, result);
+
+    while (OB_SUCC(result->next())) {
+      ASSERT_EQ(OB_SUCCESS, result->get_int("c1", result_n[0][len2]));
+      ASSERT_EQ(OB_SUCCESS, result->get_int("c2", result_n[1][len2]));
+      ++len2;
+    }
+    ASSERT_EQ(OB_ITER_END, ret);
+
+    fprintf(stdout, "test %d with parameter %ld, %ld, %ld, get %ld, %ld result rows. %ld, %ld, %ld, %ld, %ld\n", ntest, para1, para2, para3, len1, len2,
+                    result_y[0][len1 - 3], result_y[0][len1 - 2], result_y[0][len1 - 1], result_n[0][len2 - 2], result_n[0][len2 - 1]);
+    
+    ASSERT_EQ(len1, len2);
+
+    for (int64_t i = 0; i < len1; ++i) {
+      ASSERT_EQ(result_y[0][i], result_n[0][i]);
+      ASSERT_EQ(result_y[1][i], result_n[1][i]);
+    }
+  }
+
+  WRITE_SQL_BY_CONN(connection, "alter system set memtable_scan_filter_pushdown = 1;");
+}
+
+// memtable scan reach iter end without reset blockscan, which is shared among
+// different iterators, later sstable start blockscan and get wrong info.
+// TEST_F(ObTestMemtableScan, bugfix_test)
+// {
+//   DEF_VAL_FOR_SQL;
+//   ASSERT_EQ(OB_SUCCESS, get_curr_simple_server().get_sql_proxy2().acquire(connection));
+
+//   // 调大超时时间
+//   WRITE_SQL_BY_CONN(connection, "SET SESSION OB_QUERY_TIMEOUT = 1000 * 1000 * 1000 * 1000;");
+//   WRITE_SQL_BY_CONN(connection, "SET SESSION OB_TRX_TIMEOUT = 1000 * 1000 * 1000 * 1000;");
+//   WRITE_SQL_BY_CONN(connection, "SET SESSION OB_TRX_IDLE_TIMEOUT = 1000 * 1000 * 1000 * 1000;");
+
+//   // 建表
+//   WRITE_SQL_BY_CONN(
+//       connection,
+//       "CREATE TABLE test.bugfix_test (c1 BIGINT PRIMARY KEY, c2 BIGINT, c3 BIGINT);")
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE s1 START WITH 0 MINVALUE 0 MAXVALUE 200000 INCREMENT BY 1 CACHE 200000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE s2 START WITH 20000 MINVALUE 0 MAXVALUE 200000 INCREMENT BY 1 CACHE 200000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE s3 START WITH 40000 MINVALUE 0 MAXVALUE 200000 INCREMENT BY 1 CACHE 200000 ORDER;");
+
+//   WRITE_SQL_BY_CONN(connection,
+//                 "INSERT INTO                                "
+//                 "       test.bugfix_test                    "
+//                 "SELECT                                     "
+//                 "       s1.nextval c1,                      "
+//                 "       random() % 10000 c2,                "
+//                 "       uniform(1, 1000, random()) c3       "
+//                 "FROM                                       "
+//                 "       table(generator(10000));            ");
+//   fprintf(stdout, "do minor freeze once. freeze count : 0\n");
+//   minor_freeze_data_and_wait();
+
+//   WRITE_SQL_BY_CONN(connection,
+//                 "INSERT INTO                                "
+//                 "       test.bugfix_test                    "
+//                 "SELECT                                     "
+//                 "       s3.nextval c1,                      "
+//                 "       random() % 10000 c2,                "
+//                 "       uniform(1, 1000, random()) c3       "
+//                 "FROM                                       "
+//                 "       table(generator(10000));            ");
+//   fprintf(stdout, "do minor freeze once. freeze count : 1\n");
+//   minor_freeze_data_and_wait();
+
+//   WRITE_SQL_BY_CONN(connection,
+//                   "INSERT INTO                                "
+//                   "       test.bugfix_test                    "
+//                   "SELECT                                     "
+//                   "       s2.nextval c1,                      "
+//                   "       random() % 10000 c2,                "
+//                   "       zipf(1, 100, random(3)) c3          "
+//                   "FROM                                       "
+//                   "       table(generator(10000));            ");
+
+//   WRITE_SQL_BY_CONN(connection, "alter system set memtable_scan_filter_pushdown = 1;");
+//   fprintf(stdout, "prepare data done, start test ...\n");
+
+//   READ_SQL_FMT_BY_CONN(connection, "select c1, c2 from test.bugfix_test where c1 < 50000 and c3 > 300;");
+
+//   result = read_res.get_result();
+//   ASSERT_NE(nullptr, result);
+
+//   int64_t c1, len = 0;
+//   while (OB_SUCC(result->next())) {
+//     ASSERT_EQ(OB_SUCCESS, result->get_int("c1", c1));
+//     ++len;
+//   }
+//   ASSERT_EQ(OB_ITER_END, ret);
+// }
+
+// The following tests are performance test. Better use observer cluster for performance.
+// Simple server may be unstable, and the C++ code may introduce some extra unknown cost.
+
+// TEST_F(ObTestMemtableScan, memtable_scan_time_cost_prepare_data)
+// {
+//   DEF_VAL_FOR_SQL;
+//   common::ObMySQLProxy &sql_proxy = get_curr_simple_server().get_sql_proxy2();
+//   ASSERT_EQ(OB_SUCCESS, sql_proxy.acquire(connection));
+//   // 调大超时时间
+//   WRITE_SQL_BY_CONN(connection, "SET SESSION OB_QUERY_TIMEOUT = 1000 * 1000 * 1000 * 1000;");
+//   WRITE_SQL_BY_CONN(connection, "SET SESSION OB_TRX_TIMEOUT = 1000 * 1000 * 1000 * 1000;");
+//   WRITE_SQL_BY_CONN(connection, "SET SESSION OB_TRX_IDLE_TIMEOUT = 1000 * 1000 * 1000 * 1000;");
+//   sleep(5);
+
+//   // 建表
+//   WRITE_SQL_BY_CONN(
+//       connection,
+//       "CREATE TABLE test.multiple_scan_merge5 (c1 BIGINT PRIMARY KEY, c2 BIGINT, c3 BIGINT, c4 BIGINT, c5 BIGINT, c6 BIGINT, c7 BIGINT);")
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m5s0 START WITH 0 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 300 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m5s1 START WITH 1 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 300 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m5s2 START WITH 2 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 300 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m5s3 START WITH 3 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 300 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE m5s4 START WITH 0 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 1 CACHE 10000000 ORDER;");
+
+//   // 循环 4 次，每次写 1000 行，产生 4 个 mini sstable
+//   char sql_str[1024] = "";
+//   for (int64_t i = 0; i < 4; i++) {
+//     WRITE_SQL_FMT_BY_CONN(connection,
+//                           "INSERT INTO                                "
+//                           "       test.multiple_scan_merge5           "
+//                           "SELECT                                     "
+//                           "       m5s%ld.nextval c1,                  "
+//                           "       uniform(1, 1000, random()) c2,      "
+//                           "       uniform(1, 1000, random()) c3,      "
+//                           "       uniform(1, 1000, random()) c4,      "
+//                           "       uniform(1, 1000, random()) c5,      "
+//                           "       uniform(1, 1000, random()) c6,      "
+//                           "       uniform(1, 1000, random()) c7       "
+//                           "FROM                                       "
+//                           "       table(generator(1000));             ", i);
+//     fprintf(stdout, "do minor freeze once. freeze count : %ld\n", i+1);
+//     minor_freeze_data_and_wait();
+//   }
+
+//   // 写 100000 行数据到 memtable
+//   WRITE_SQL_BY_CONN(connection,
+//                     "INSERT IGNORE INTO                         "
+//                     "       test.multiple_scan_merge5           "
+//                     "SELECT                                     "
+//                     "       m5s4.nextval c1,                    "
+//                     "       uniform(1, 1000, random()) c2,      "
+//                     "       uniform(1, 1000, random()) c3,      "
+//                     "       uniform(1, 1000, random()) c4,      "
+//                     "       uniform(1, 1000, random()) c5,      "
+//                     "       uniform(1, 1000, random()) c6,      "
+//                     "       uniform(1, 1000, random()) c7       "
+//                     "FROM                                       "
+//                     "       table(generator(100000));           ");
+
+//   fprintf(stdout, "prepare data done, start time cost test ...\n");
+//   WRITE_SQL_BY_CONN(connection, "alter system set memtable_scan_filter_pushdown = 1;");
+// }
+
+// TEST_F(ObTestMemtableScan, memtable_scan_time_cost_with_no_filter)
+// {
+//   DEF_VAL_FOR_SQL;
+//   common::ObMySQLProxy &sql_proxy = get_curr_simple_server().get_sql_proxy2();
+//   ASSERT_EQ(OB_SUCCESS, sql_proxy.acquire(connection));
+
+//   clock_t start, end;
+//   int64_t res_len, c1;
+
+//   // TODO(jianxian): outter loop for differetn parameters.
+//   WRITE_SQL_BY_CONN(connection, "alter system set memtable_scan_filter_pushdown = 1;");
+//   sleep(5);
+//   for (int i = 0; i < 5; ++i) {
+//     res_len = 0;
+//     start = clock();
+//     READ_SQL_FMT_BY_CONN(connection, "select c1, c2, c6 from test.multiple_scan_merge5 where "
+//                                      "(c1 < 100000);");
+//     result = read_res.get_result();
+//     ASSERT_NE(nullptr, result);
+
+//     while (OB_SUCC(result->next())) {
+//       ASSERT_EQ(OB_SUCCESS, result->get_int("c1", c1));
+//       ++res_len;
+//     }
+
+//     ASSERT_EQ(OB_ITER_END, ret);
+//     end = clock();
+//     fprintf(stdout, "get %ld result rows with blockscan, use time %f\n", res_len, (double)(end - start) / CLOCKS_PER_SEC);
+//   }
+
+//   WRITE_SQL_BY_CONN(connection, "alter system set memtable_scan_filter_pushdown = 0;");
+//   sleep(5);
+//   for (int i = 0; i < 5; ++i) {
+//     res_len = 0;
+//     start = clock();
+//     READ_SQL_FMT_BY_CONN(connection, "select c1, c2, c6 from test.multiple_scan_merge5 where"
+//                                      "(c1 < 100000);");
+//     result = read_res.get_result();
+//     ASSERT_NE(nullptr, result);
+
+//     while (OB_SUCC(result->next())) {
+//       ASSERT_EQ(OB_SUCCESS, result->get_int("c1", c1));
+//       ++res_len;
+//     }
+
+//     ASSERT_EQ(OB_ITER_END, ret);
+//     end = clock();
+//     fprintf(stdout, "get %ld result rows without blockscan, use time %f\n", res_len, (double)(end - start) / CLOCKS_PER_SEC);
+//   }
+
+//   WRITE_SQL_BY_CONN(connection, "alter system set memtable_scan_filter_pushdown = 1;");
+// }
+
+// TEST_F(ObTestMemtableScan, memtable_scan_time_cost_with_simple_filter)
+// {
+//   DEF_VAL_FOR_SQL;
+//   common::ObMySQLProxy &sql_proxy = get_curr_simple_server().get_sql_proxy2();
+//   ASSERT_EQ(OB_SUCCESS, sql_proxy.acquire(connection));
+
+//   clock_t start, end;
+//   int64_t res_len, c1;
+
+//   // TODO(jianxian): outter loop for differetn parameters.
+//   WRITE_SQL_BY_CONN(connection, "alter system set memtable_scan_filter_pushdown = 1;");
+//   sleep(5);
+//   for (int i = 0; i < 5; ++i) {
+//     res_len = 0;
+//     start = clock();
+//     READ_SQL_FMT_BY_CONN(connection, "select c1, c2, c6 from test.multiple_scan_merge5 where "
+//                                      "(c1 < 100000) and (c2 < 700);");
+//     result = read_res.get_result();
+//     ASSERT_NE(nullptr, result);
+
+//     while (OB_SUCC(result->next())) {
+//       ASSERT_EQ(OB_SUCCESS, result->get_int("c1", c1));
+//       ++res_len;
+//     }
+
+//     ASSERT_EQ(OB_ITER_END, ret);
+//     end = clock();
+//     fprintf(stdout, "get %ld result rows with blockscan, use time %f\n", res_len, (double)(end - start) / CLOCKS_PER_SEC);
+//   }
+
+//   WRITE_SQL_BY_CONN(connection, "alter system set memtable_scan_filter_pushdown = 0;");
+//   sleep(5);
+//   for (int i = 0; i < 5; ++i) {
+//     res_len = 0;
+//     start = clock();
+//     READ_SQL_FMT_BY_CONN(connection, "select c1, c2, c6 from test.multiple_scan_merge5 where "
+//                                      "(c1 < 100000) and (c2 < 700);");
+//     result = read_res.get_result();
+//     ASSERT_NE(nullptr, result);
+
+//     while (OB_SUCC(result->next())) {
+//       ASSERT_EQ(OB_SUCCESS, result->get_int("c1", c1));
+//       ++res_len;
+//     }
+
+//     ASSERT_EQ(OB_ITER_END, ret);
+//     end = clock();
+//     fprintf(stdout, "get %ld result rows without blockscan, use time %f\n", res_len, (double)(end - start) / CLOCKS_PER_SEC);
+//   }
+
+//   WRITE_SQL_BY_CONN(connection, "alter system set memtable_scan_filter_pushdown = 1;");
+// }
+
+// TEST_F(ObTestMemtableScan, memtable_scan_time_cost_with_complex_filter)
+// {
+//   DEF_VAL_FOR_SQL;
+//   common::ObMySQLProxy &sql_proxy = get_curr_simple_server().get_sql_proxy2();
+//   ASSERT_EQ(OB_SUCCESS, sql_proxy.acquire(connection));
+
+//   clock_t start, end;
+//   int64_t res_len, c1;
+
+//   // TODO(jianxian): outter loop for differetn parameters.
+//   WRITE_SQL_BY_CONN(connection, "alter system set memtable_scan_filter_pushdown = 1;");
+//   sleep(5);
+//   for (int i = 0; i < 5; ++i) {
+//     res_len = 0;
+//     start = clock();
+//     READ_SQL_FMT_BY_CONN(connection, "select c1, c2, c6 from test.multiple_scan_merge5 where "
+//                                      "(c1 < 100000) and (c2 < 700) and (c3 > 300) and (c4 * 2 < 1200) and (c5 + 100 > 200);");
+//     result = read_res.get_result();
+//     ASSERT_NE(nullptr, result);
+
+//     while (OB_SUCC(result->next())) {
+//       ASSERT_EQ(OB_SUCCESS, result->get_int("c1", c1));
+//       ++res_len;
+//     }
+
+//     ASSERT_EQ(OB_ITER_END, ret);
+//     end = clock();
+//     fprintf(stdout, "get %ld result rows with blockscan, use time %f\n", res_len, (double)(end - start) / CLOCKS_PER_SEC);
+//   }
+
+//   WRITE_SQL_BY_CONN(connection, "alter system set memtable_scan_filter_pushdown = 0;");
+//   sleep(5);
+//   for (int i = 0; i < 5; ++i) {
+//     res_len = 0;
+//     start = clock();
+//     READ_SQL_FMT_BY_CONN(connection, "select c1, c2, c6 from test.multiple_scan_merge5 where "
+//                                      "(c1 < 100000) and (c2 < 700) and (c3 > 300) and (c4 * 2 < 1200) and (c5 + 100 > 200);");
+//     result = read_res.get_result();
+//     ASSERT_NE(nullptr, result);
+
+//     while (OB_SUCC(result->next())) {
+//       ASSERT_EQ(OB_SUCCESS, result->get_int("c1", c1));
+//       ++res_len;
+//     }
+
+//     ASSERT_EQ(OB_ITER_END, ret);
+//     end = clock();
+//     fprintf(stdout, "get %ld result rows without blockscan, use time %f\n", res_len, (double)(end - start) / CLOCKS_PER_SEC);
+//   }
+
+//   WRITE_SQL_BY_CONN(connection, "alter system set memtable_scan_filter_pushdown = 1;");
+// }
+
+// TEST_F(ObTestMemtableScan, memtable_scan_time_cost_worst_case)
+// {
+//   DEF_VAL_FOR_SQL;
+//   common::ObMySQLProxy &sql_proxy = get_curr_simple_server().get_sql_proxy2();
+//   ASSERT_EQ(OB_SUCCESS, sql_proxy.acquire(connection));
+//   // 调大超时时间
+//   WRITE_SQL_BY_CONN(connection, "SET SESSION OB_QUERY_TIMEOUT = 1000 * 1000 * 1000 * 1000;");
+//   WRITE_SQL_BY_CONN(connection, "SET SESSION OB_TRX_TIMEOUT = 1000 * 1000 * 1000 * 1000;");
+//   WRITE_SQL_BY_CONN(connection, "SET SESSION OB_TRX_IDLE_TIMEOUT = 1000 * 1000 * 1000 * 1000;");
+//   sleep(5);
+
+//   // 建表
+//   WRITE_SQL_BY_CONN(
+//       connection,
+//       "CREATE TABLE test.multiple_scan_merge3 (c1 BIGINT PRIMARY KEY, c2 BIGINT, c3 BIGINT, c4 BIGINT, c5 BIGINT, c6 VARCHAR(10));")
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE wcs0 START WITH 0 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 5 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE wcs1 START WITH 1 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 5 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE wcs2 START WITH 2 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 5 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE wcs3 START WITH 3 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 5 CACHE 10000000 ORDER;");
+//   WRITE_SQL_BY_CONN(connection, "CREATE SEQUENCE wcs4 START WITH 4 MINVALUE 0 MAXVALUE 100000000 INCREMENT BY 5 CACHE 10000000 ORDER;");
+
+//   // 循环 4 次，每次写 10000 行，产生 4 个 mini sstable
+//   char sql_str[1024] = "";
+//   for (int64_t i = 0; i < 4; i++) {
+//     WRITE_SQL_FMT_BY_CONN(connection,
+//                           "INSERT INTO                                "
+//                           "       test.multiple_scan_merge3           "
+//                           "SELECT                                     "
+//                           "       wcs%ld.nextval c1,                  "
+//                           "       random() %% 10000 c2,               "
+//                           "       zipf(1, 100, random(3)) c3,         "
+//                           "       uniform(1, 100, random()) c4,       "
+//                           "       uniform(1, 100, random()) c5,       "
+//                           "       randstr(10, random()) c6            "
+//                           "FROM                                       "
+//                           "       table(generator(10000));            ", i);
+//     fprintf(stdout, "do minor freeze once. freeze count : %ld\n", i+1);
+//     minor_freeze_data_and_wait();
+//   }
+
+//   // 写 10000 行数据到 memtable
+//   WRITE_SQL_BY_CONN(connection,
+//                     "INSERT INTO                         "
+//                     "       test.multiple_scan_merge3           "
+//                     "SELECT                                     "
+//                     "       wcs4.nextval c1,                    "
+//                     "       uniform(1, 1000, random()) c2,      "
+//                     "       uniform(1, 1000, random()) c3,      "
+//                     "       uniform(1, 1000, random()) c4,      "
+//                     "       uniform(1, 1000, random()) c5,      "
+//                     "       randstr(10, random()) c6            "
+//                     "FROM                                       "
+//                     "       table(generator(10000));           ");
+
+//   fprintf(stdout, "prepare data done, start time cost test ...\n");
+
+//   clock_t start, end;
+//   int64_t res_len, c1;
+
+//   WRITE_SQL_BY_CONN(connection, "alter system set memtable_scan_filter_pushdown = 1;");
+//   sleep(5);
+//   for (int i = 0; i < 5; ++i) {
+//     res_len = 0;
+//     start = clock();
+//     READ_SQL_FMT_BY_CONN(connection, "select c1, c2, c6 from test.multiple_scan_merge3 where "
+//                                      "(c1 < 100000) and (c2 < 700);");
+//     result = read_res.get_result();
+//     ASSERT_NE(nullptr, result);
+
+//     while (OB_SUCC(result->next())) {
+//       ASSERT_EQ(OB_SUCCESS, result->get_int("c1", c1));
+//       ++res_len;
+//     }
+
+//     ASSERT_EQ(OB_ITER_END, ret);
+//     end = clock();
+//     fprintf(stdout, "get %ld result rows with blockscan, use time %f\n", res_len, (double)(end - start) / CLOCKS_PER_SEC);
+//   }
+
+//   WRITE_SQL_BY_CONN(connection, "alter system set memtable_scan_filter_pushdown = 0;");
+//   sleep(5);
+//   for (int i = 0; i < 5; ++i) {
+//     res_len = 0;
+//     start = clock();
+//     READ_SQL_FMT_BY_CONN(connection, "select c1, c2, c6 from test.multiple_scan_merge3 where "
+//                                      "(c1 < 100000) and (c2 < 700);");
+//     result = read_res.get_result();
+//     ASSERT_NE(nullptr, result);
+
+//     while (OB_SUCC(result->next())) {
+//       ASSERT_EQ(OB_SUCCESS, result->get_int("c1", c1));
+//       ++res_len;
+//     }
+
+//     ASSERT_EQ(OB_ITER_END, ret);
+//     end = clock();
+//     fprintf(stdout, "get %ld result rows without blockscan, use time %f\n", res_len, (double)(end - start) / CLOCKS_PER_SEC);
+//   }
+// }
+
+TEST_F(ObTestMemtableScan, end)
+{
+  if (RunCtx.time_sec_ > 0) {
+    ::sleep(RunCtx.time_sec_);
+  }
+}
+
+} // end unittest
+} // end oceanbase
+
+
+int main(int argc, char **argv)
+{
+  int c = 0;
+  int time_sec = 0;
+  char *log_level = (char*)"INFO";
+  srand((unsigned)time(NULL));
+  while(EOF != (c = getopt(argc,argv,"t:l:"))) {
+    switch(c) {
+    case 't':
+      time_sec = atoi(optarg);
+      break;
+    case 'l':
+     log_level = optarg;
+     oceanbase::unittest::ObSimpleClusterTestBase::enable_env_warn_log_ = false;
+     break;
+    default:
+      break;
+    }
+  }
+  oceanbase::unittest::init_log_and_gtest(argc, argv);
+  OB_LOGGER.set_log_level(log_level);
+
+  LOG_INFO("main>>>");
+  oceanbase::unittest::RunCtx.time_sec_ = time_sec;
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/share/parameter/ob_parameter_seed.ipp
+++ b/src/share/parameter/ob_parameter_seed.ipp
@@ -728,6 +728,12 @@ DEF_STR_WITH_CHECKER(_rpc_checksum, OB_CLUSTER_PARAMETER, "Force",
 DEF_TIME(_ob_trans_rpc_timeout, OB_CLUSTER_PARAMETER, "3s", "[0s, 3600s]",
          "transaction rpc timeout(s). Range: [0s, 3600s]",
          ObParameterAttr(Section::TRANS, Source::DEFAULT, EditLevel::DYNAMIC_EFFECTIVE));
+DEF_INT(memtable_scan_filter_pushdown, OB_TENANT_PARAMETER, "1", "[0, 1]",
+        "use blockscan for memtable scan",
+        ObParameterAttr(Section::TRANS, Source::DEFAULT, EditLevel::DYNAMIC_EFFECTIVE));
+DEF_DBL(memtable_scan_optimization_threshold, OB_TENANT_PARAMETER, "2", "[0,]",
+        "the threshold of memtable sstable row count to turn on memtable scan optimization",
+        ObParameterAttr(Section::TRANS, Source::DEFAULT, EditLevel::DYNAMIC_EFFECTIVE));
 DEF_BOOL(enable_early_lock_release, OB_TENANT_PARAMETER, "True",
          "enable early lock release",
          ObParameterAttr(Section::OBSERVER, Source::DEFAULT, EditLevel::DYNAMIC_EFFECTIVE));

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -540,6 +540,7 @@ ob_set_subtarget(ob_storage memtable
   memtable/ob_row_compactor.cpp
   memtable/ob_row_conflict_handler.cpp
   memtable/ob_concurrent_control.cpp
+  memtable/ob_memtable_block_row_scanner.cpp
 )
 
 ob_set_subtarget(ob_storage memtable_mvcc

--- a/src/storage/access/ob_multiple_scan_merge.h
+++ b/src/storage/access/ob_multiple_scan_merge.h
@@ -54,6 +54,10 @@ protected:
   int set_rows_merger(const int64_t table_cnt);
 private:
   int prepare_blockscan(ObStoreRowIterator &iter);
+  int calc_mem2sst_rowcnt_ratio(
+      common::ObSEArray<storage::ObITable *, common::DEFAULT_STORE_CNT_IN_STORAGE> tables,
+      const int64_t table_cnt,
+      double &mem2sst_rowcnt_ratio);
 protected:
   ObScanMergeLoserTreeCmp tree_cmp_;
   ObScanSimpleMerger *simple_merge_;
@@ -65,6 +69,7 @@ protected:
 private:
   const blocksstable::ObDatumRange *range_;
   blocksstable::ObDatumRange cow_range_;
+  blocksstable::ObDatumRowkey border_key_;
 
   // disallow copy
   DISALLOW_COPY_AND_ASSIGN(ObMultipleScanMerge);

--- a/src/storage/access/ob_store_row_iterator.h
+++ b/src/storage/access/ob_store_row_iterator.h
@@ -79,14 +79,15 @@ public:
     UNUSED(rowkey);
     return OB_NOT_SUPPORTED;
   }
+  bool is_block_row_store_null() const { return nullptr == block_row_store_; }
   bool can_blockscan() const
   {
-    return (IteratorScan == type_ || IteratorMultiScan == type_) && is_sstable_iter_ &&
+    return (IteratorScan == type_ || IteratorMultiScan == type_) &&
         nullptr != block_row_store_ && block_row_store_->can_blockscan();
   }
   bool filter_applied() const
   {
-    return (IteratorScan == type_ || IteratorMultiScan == type_) && is_sstable_iter_ &&
+    return (IteratorScan == type_ || IteratorMultiScan == type_) &&
         nullptr != block_row_store_ && block_row_store_->filter_applied();
   }
   virtual int get_next_row(const blocksstable::ObDatumRow *&row);

--- a/src/storage/access/ob_table_access_param.cpp
+++ b/src/storage/access/ob_table_access_param.cpp
@@ -42,6 +42,7 @@ ObTableIterParam::ObTableIterParam()
       is_for_foreign_check_(false),
       limit_prefetch_(false),
       ss_rowkey_prefix_cnt_(0),
+      mem2sst_rowcnt_ratio_(0),
       op_(nullptr),
       pd_storage_flag_(0)
 {
@@ -65,6 +66,7 @@ void ObTableIterParam::reset()
   pd_storage_flag_ = 0;
   pushdown_filter_ = nullptr;
   ss_rowkey_prefix_cnt_ = 0;
+  mem2sst_rowcnt_ratio_ = 0;
   vectorized_enabled_ = false;
   has_virtual_columns_ = false;
   has_lob_column_out_ = false;
@@ -132,7 +134,8 @@ DEF_TO_STRING(ObTableIterParam)
        K_(has_lob_column_out),
        K_(is_for_foreign_check),
        K_(limit_prefetch),
-       K_(ss_rowkey_prefix_cnt));
+       K_(ss_rowkey_prefix_cnt),
+       K_(mem2sst_rowcnt_ratio));
   J_OBJ_END();
   return pos;
 }

--- a/src/storage/access/ob_table_access_param.h
+++ b/src/storage/access/ob_table_access_param.h
@@ -124,6 +124,10 @@ public:
   { return get_group_idx_col_index() != common::OB_INVALID_INDEX; }
   OB_INLINE int64_t get_ss_rowkey_prefix_cnt() const
   { return ss_rowkey_prefix_cnt_; }
+  OB_INLINE double get_mem2sst_rowcnt_ratio() const
+  { return mem2sst_rowcnt_ratio_; }
+  OB_INLINE void set_mem2sst_rowcnt_ratio(double mrr)
+  { mem2sst_rowcnt_ratio_ = mrr; }
   OB_INLINE void disable_blockscan()
   { pd_blockscan_ = 0; }
   OB_INLINE bool enable_pd_blockscan() const
@@ -161,6 +165,7 @@ public:
   bool is_for_foreign_check_;
   bool limit_prefetch_;
   int64_t ss_rowkey_prefix_cnt_;
+  double mem2sst_rowcnt_ratio_;
   sql::ObPushdownOperator *op_;
   union {
     struct {

--- a/src/storage/memtable/ob_memtable.cpp
+++ b/src/storage/memtable/ob_memtable.cpp
@@ -865,9 +865,23 @@ int ObMemtable::scan(
         }
       }
     } else {
-      ALLOCATE_TABLE_STORE_ROW_IETRATOR(context,
-            ObMemtableScanIterator,
-            scan_iter_ptr);
+      // omt::ObTenantConfigGuard tenant_config(TENANT_CONF(MTL_ID()));
+      // TODO(jianxian): use config or const for the threshold 2.
+      if (param.enable_pd_blockscan() && param.get_mem2sst_rowcnt_ratio() >= 2) {
+        ALLOCATE_TABLE_STORE_ROW_IETRATOR(context,
+              ObMemtableBlockScanIterator,
+              scan_iter_ptr);
+        // TRANS_LOG(INFO, "Memtable scan iterator choice : blockscan",
+        //           K(param.get_mem2sst_rowcnt_ratio()),
+        //           K(real_range), K(param), K(context));
+      } else {
+        ALLOCATE_TABLE_STORE_ROW_IETRATOR(context,
+              ObMemtableScanIterator,
+              scan_iter_ptr);
+        // TRANS_LOG(INFO, "Memtable scan iterator choice : normal",
+        //           K(param.get_mem2sst_rowcnt_ratio()),
+        //           K(real_range), K(param), K(context));
+      }
       if (OB_SUCC(ret)) {
         if (NULL == scan_iter_ptr) {
           ret = OB_ERR_UNEXPECTED;

--- a/src/storage/memtable/ob_memtable_block_row_scanner.cpp
+++ b/src/storage/memtable/ob_memtable_block_row_scanner.cpp
@@ -1,0 +1,270 @@
+/**
+ * Copyright (c) 2021 OceanBase
+ * OceanBase CE is licensed under Mulan PubL v2.
+ * You can use this software according to the terms and conditions of the Mulan PubL v2.
+ * You may obtain a copy of Mulan PubL v2 at:
+ *          http://license.coscl.org.cn/MulanPubL-2.0
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PubL v2 for more details.
+ */
+
+#include "ob_memtable_block_row_scanner.h"
+#include "storage/access/ob_block_row_store.h"
+#include "storage/blocksstable/ob_row_reader.h"
+
+namespace oceanbase
+{
+namespace memtable
+{
+
+
+ObMemtableBlockRowScanner::ObMemtableBlockRowScanner()
+    : last_batch_(false),
+      end_of_iter_(false),
+      is_inited_(false),
+      cur_idx_(0),
+      batch_size_(0),
+      allocator_(NULL),
+      result_bitmap_(NULL),
+      read_info_(NULL)
+{
+}
+
+ObMemtableBlockRowScanner::~ObMemtableBlockRowScanner()
+{
+  reset();
+}
+
+int ObMemtableBlockRowScanner::init(
+    common::ObIAllocator *allocator,
+    const int64_t capacity,
+    char *trans_info_ptr,
+    const storage::ObITableReadInfo *read_info)
+{
+  if (is_inited_) {
+    reset();
+  }
+  int ret = OB_SUCCESS;
+  allocator_ = allocator;
+  read_info_ = read_info;
+  for (int i = 0; i < ObMemtableBlockRowScanner::MAX_ROW_BATCH_SIZE; ++i) {
+    if (OB_FAIL(rows_[i].init(*allocator_, capacity, trans_info_ptr))) {
+      STORAGE_LOG(WARN, "Fail to init memtable scan row batch", K(ret), K(i));
+      break;
+    }
+  }
+  if (OB_SUCC(ret)) {
+    is_inited_ = true;
+  }
+  return ret;
+}
+
+void ObMemtableBlockRowScanner::reset()
+{
+  for (int i = 0; i < ObMemtableBlockRowScanner::MAX_ROW_BATCH_SIZE; ++i) {
+    rows_[i].reset();
+  }
+  last_batch_ = false;
+  end_of_iter_ = false;
+  cur_idx_ = 0;
+  batch_size_ = 0;
+  result_bitmap_ = nullptr;
+}
+
+void ObMemtableBlockRowScanner::reuse()
+{
+  last_batch_ = false;
+  end_of_iter_ = false;
+  cur_idx_ = 0;
+  batch_size_ = 0;
+  result_bitmap_ = nullptr;
+}
+
+blocksstable::ObDatumRow *ObMemtableBlockRowScanner::get_next_row(bool fast_filter_skipped)
+{
+  rows_[cur_idx_].fast_filter_skipped_ = fast_filter_skipped;
+  return rows_ + (cur_idx_++);
+}
+
+bool ObMemtableBlockRowScanner::has_cached_row()
+{
+  bool ret_valid = false;
+  if (OB_ISNULL(result_bitmap_)) {
+    // no bitmap, directly return next row in cur_idx_;
+    ret_valid = (cur_idx_ < batch_size_);
+  } else if (cur_idx_ < batch_size_) {
+    int iter = cur_idx_;
+    // find next row which is not filtered by the result bimap.
+    for (; iter < batch_size_ && !result_bitmap_->test(iter); ++iter) {}
+    if (iter < batch_size_) {
+      // if find one, update cur_idx_ to avoid next search.
+      cur_idx_ = iter;
+      ret_valid = true;
+    } else {
+      // all rows left in current batch are filtered out.
+      ret_valid = false;
+    }
+  } else {
+    // the rows in the current batch have been used up.
+    ret_valid = false;
+  }
+  return ret_valid;
+}
+
+int ObMemtableBlockRowScanner::filter_pushdown_filter(
+    sql::ObPushdownFilterExecutor *parent,
+    sql::ObPushdownFilterExecutor *filter,
+    storage::PushdownFilterInfo &pd_filter_info,
+    common::ObBitmap &bitmap)
+{
+  int ret = OB_SUCCESS;
+  blocksstable::ObStorageDatum *col_buf = pd_filter_info.datum_buf_;
+  // TODO(jianxian): validate_filter_info.
+  int64_t col_count = filter->get_col_count();
+  const common::ObIArray<int32_t> &col_offsets = filter->get_col_offsets();
+  const sql::ColumnParamFixedArray &col_params = filter->get_col_params();
+  const common::ObIArray<blocksstable::ObStorageDatum> &default_datums = filter->get_default_datums();
+  const blocksstable::ObColDescIArray &cols_desc = read_info_->get_columns_desc();
+
+  for (int64_t row_idx = 0; OB_SUCC(ret) && row_idx < batch_size_; ++row_idx) {
+    if (nullptr != parent && parent->can_skip_filter(row_idx)) {
+      continue;
+    } else if (0 < col_count) {
+      blocksstable::ObDatumRow *cur_row = rows_ + row_idx;
+      for (int i = 0; OB_SUCC(ret) && i < col_count; ++i) {
+        int64_t col_idx = col_offsets.at(i);
+        blocksstable::ObStorageDatum &datum = col_buf[i];
+        datum = cur_row->storage_datums_[col_idx];
+        if (datum.is_nop_value()) {
+          // TODO(jianxian): check default_datums size, use i or col_idx.
+          if (OB_LIKELY(!default_datums.at(i).is_nop())) {
+            datum = default_datums.at(i);
+          } else {
+            ret = OB_ERR_UNEXPECTED;
+            STORAGE_LOG(WARN, "Unexpected nop value", K(i), K(col_idx), K(*cur_row));
+          }
+        }
+        if (OB_FAIL(ret)) {
+        } else if (nullptr != col_params.at(i) && !datum.is_null() &&
+                   OB_FAIL(storage::pad_column(
+                           col_params.at(i)->get_meta_type(),
+                           col_params.at(i)->get_accuracy(),
+                           *allocator_,
+                           datum))) {
+          STORAGE_LOG(WARN, "Failed to pad column", K(ret), K(i), K(col_idx), K(row_idx), K(datum));
+        }
+      }
+    }
+    bool filtered = false;
+    if (OB_SUCC(ret)) {
+      if (filter->is_filter_black_node()) {
+        sql::ObBlackFilterExecutor &black_filter = static_cast<sql::ObBlackFilterExecutor &>(*filter);
+        if (OB_FAIL(black_filter.filter(col_buf, col_count, filtered))) {
+          STORAGE_LOG(WARN, "Failed to filter row with black filter", K(ret), K(row_idx));
+        }
+      } else {
+        sql::ObWhiteFilterExecutor &white_filter = static_cast<sql::ObWhiteFilterExecutor &>(*filter);
+        common::ObObj obj;
+        if (1 != filter->get_col_count()) {
+          ret = OB_ERR_UNEXPECTED;
+          STORAGE_LOG(WARN, "Unexpected col_ids count: not 1", K(ret), K(filter), K(filter->get_col_count()));
+        } else if (OB_FAIL(col_buf[0].to_obj_enhance(obj, cols_desc.at(col_offsets.at(0)).col_type_))) {
+          STORAGE_LOG(WARN, "Failed to obj", K(ret), K(row_idx), K(col_buf[0]));
+        } else if (OB_FAIL(filter_white_filter(white_filter, obj, filtered))) {
+          STORAGE_LOG(WARN, "Failed to filter row with white filter", K(ret), K(row_idx));
+        }
+      }
+      if (OB_FAIL(ret)) {
+      } else if (!filtered) {
+        if (OB_FAIL(bitmap.set(row_idx))) {
+          STORAGE_LOG(WARN, "Failed to set result bitmap", K(ret), K(row_idx));
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+int ObMemtableBlockRowScanner::filter_white_filter(
+    const sql::ObWhiteFilterExecutor &filter,
+    const common::ObObj &obj,
+    bool &filtered)
+{
+  int ret = OB_SUCCESS;
+  filtered = true;
+  const sql::ObWhiteFilterOperatorType op_type = filter.get_op_type();
+  if (OB_UNLIKELY(sql::WHITE_OP_MAX <= op_type)) {
+    ret = OB_INVALID_ARGUMENT;
+    STORAGE_LOG(WARN, "Invalid operator type of Filter node", K(ret), K(filter));
+  } else {
+    const ObIArray<ObObj> &ref_objs = filter.get_objs();
+    switch (op_type) {
+      case sql::WHITE_OP_NN: {
+        if ((lib::is_mysql_mode() && !obj.is_null())
+            || (lib::is_oracle_mode() && !obj.is_null_oracle())) {
+          filtered = false;
+        }
+        break;
+      }
+      case sql::WHITE_OP_NU: {
+        if ((lib::is_mysql_mode() && obj.is_null())
+            || (lib::is_oracle_mode() && obj.is_null_oracle())) {
+          filtered = false;
+        }
+        break;
+      }
+      case sql::WHITE_OP_EQ:
+      case sql::WHITE_OP_NE:
+      case sql::WHITE_OP_GT:
+      case sql::WHITE_OP_GE:
+      case sql::WHITE_OP_LT:
+      case sql::WHITE_OP_LE: {
+        if (OB_UNLIKELY(ref_objs.count() != 1)) {
+          ret = OB_INVALID_ARGUMENT;
+          STORAGE_LOG(WARN, "Invalid argument for comparison operator", K(ret), K(ref_objs));
+        } else if ((lib::is_mysql_mode() && (obj.is_null() || ref_objs.at(0).is_null()))
+                    || (lib::is_oracle_mode() && (obj.is_null_oracle() || ref_objs.at(0).is_null_oracle()))) {
+          // Result of compare with null is null
+        } else if (ObObjCmpFuncs::compare_oper_nullsafe(
+                   obj,
+                   ref_objs.at(0),
+                   obj.get_collation_type(),
+                   sql::ObPushdownWhiteFilterNode::WHITE_OP_TO_CMP_OP[op_type])) {
+          filtered = false;
+        }
+        break;
+      }
+      case sql::WHITE_OP_BT: {
+        if (OB_UNLIKELY(ref_objs.count() != 2)) {
+          ret = OB_INVALID_ARGUMENT;
+          STORAGE_LOG(WARN, "Invalid argument for between operators", K(ret), K(ref_objs));
+        } else if ((lib::is_mysql_mode() && obj.is_null())
+                    || (lib::is_oracle_mode() && obj.is_null_oracle())) {
+          // Result of compare with null is null
+        } else if (obj >= ref_objs.at(0) && obj <= ref_objs.at(1)) {
+          filtered = false;
+        }
+        break;
+      }
+      case sql::WHITE_OP_IN: {
+        bool is_existed = false;
+        if (OB_FAIL(filter.exist_in_obj_set(obj, is_existed))) {
+          STORAGE_LOG(WARN, "Failed to check object in hashset", K(ret), K(obj));
+        } else if (is_existed) {
+          filtered = false;
+        }
+        break;
+      }
+      default: {
+        ret = OB_NOT_SUPPORTED;
+        STORAGE_LOG(WARN, "Unexpected filter pushdown operation type", K(ret), K(op_type));
+      }
+    } // end of switch
+  }
+  return ret;
+}
+
+} // end of namespace memtable
+} // end of namespace oceanbase

--- a/src/storage/memtable/ob_memtable_block_row_scanner.h
+++ b/src/storage/memtable/ob_memtable_block_row_scanner.h
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2021 OceanBase
+ * OceanBase CE is licensed under Mulan PubL v2.
+ * You can use this software according to the terms and conditions of the Mulan PubL v2.
+ * You may obtain a copy of Mulan PubL v2 at:
+ *          http://license.coscl.org.cn/MulanPubL-2.0
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PubL v2 for more details.
+ */
+
+#ifndef OB_STORAGE_MEMTABLE_OB_MEMTABLE_BLOCK_ROW_SCANNER_H_
+#define OB_STORAGE_MEMTABLE_OB_MEMTABLE_BLOCK_ROW_SCANNER_H_
+
+#include "sql/engine/basic/ob_pushdown_filter.h"
+#include "storage/access/ob_table_read_info.h"
+
+namespace oceanbase
+{
+namespace storage
+{
+  class PushdownFilterInfo;
+}
+namespace memtable
+{
+// This class provides batch scan and filter pushdown function for memtable.
+// It is similar to class ObMicroBlockRowScanner for micor block (both are
+// intermediate classes between Iterator and ObBlockRowStore).
+class ObMemtableBlockRowScanner {
+private:
+  static const int64_t MAX_ROW_BATCH_SIZE = 225;
+  // If this batch reach the border key while constructing current batch.
+  bool last_batch_;
+  // If iterator reach the end while constructing current batch.
+  bool end_of_iter_;
+  // If this class has been inited.
+  bool is_inited_;
+  // Next index to get a new row in current batch.
+  int64_t cur_idx_;
+  // The number of rows after constructing current batch.
+  int64_t batch_size_;
+  common::ObIAllocator *allocator_;
+  // The bitmap result after pushdown filter calculated.
+  const common::ObBitmap *result_bitmap_;
+  const storage::ObITableReadInfo *read_info_;
+  // Current batch of rows.
+  blocksstable::ObDatumRow rows_[MAX_ROW_BATCH_SIZE];
+public:
+  ObMemtableBlockRowScanner();
+  virtual ~ObMemtableBlockRowScanner();
+  OB_INLINE bool is_full() const { return batch_size_ == MAX_ROW_BATCH_SIZE; }
+  OB_INLINE bool has_reached_iter_end() const { return end_of_iter_; }
+  OB_INLINE bool has_reached_border_key() const { return last_batch_; }
+  OB_INLINE void set_reach_iter_end() { end_of_iter_ = true; }
+  OB_INLINE void set_last_batch() { last_batch_ = true; }
+  OB_INLINE void set_bitmap(const common::ObBitmap *bitmap) { result_bitmap_ = bitmap; }
+  OB_INLINE void increase_size() { ++batch_size_; }
+  OB_INLINE int64_t size() const { return batch_size_; }
+  OB_INLINE const common::ObBitmap *get_bitmap() { return result_bitmap_; }
+  OB_INLINE blocksstable::ObDatumRow *next_new_row() { return rows_ + (batch_size_); }
+  int init(
+      common::ObIAllocator *allocator,
+      const int64_t capacity,
+      char *trans_info_ptr,
+      const storage::ObITableReadInfo *read_info);
+  void reset();
+  void reuse();
+  blocksstable::ObDatumRow *get_next_row(bool fast_filter_skipped);
+  bool has_cached_row();
+  int filter_pushdown_filter(
+      sql::ObPushdownFilterExecutor *parent,
+      sql::ObPushdownFilterExecutor *filter,
+      storage::PushdownFilterInfo &pd_filter_info,
+      common::ObBitmap &bitmap);
+  // TODO(jianxian): this function is the same as ObIMicroBlockReader::filter_white_filter,
+  // and it needs to be considered whether it can be reused.
+  int filter_white_filter(
+      const sql::ObWhiteFilterExecutor &filter,
+      const common::ObObj &obj,
+      bool &filtered);
+};
+} // end of namespace memtable
+} // end of namespace oceanbase
+#endif


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase**! 
Please read the [How to Contribute](https://github.com/oceanbase/oceanbase/wiki/how_to_contribute) document **BEFORE** filling this PR.

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description
close #1503
<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->

### Solution Description

<!-- Please clearly and consice descipt the solution. -->
(1) First, enable single edge table scan for memtable, which is the basis for later optimization.
(2) Second, acquire a batch of rows instead of only one.
(3) Third, use bitmap result to calculate the whole batch.

### Passed Regressions

<!-- Unittest, mysql test or test it manually? -->

### Upgrade Compatibility

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

### Other Information

<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
