### PR TITLE
feat: add expression propagation for case when rewrite 

### DIFF
--- a/src/sql/rewrite/ob_transform_const_propagate.cpp
+++ b/src/sql/rewrite/ob_transform_const_propagate.cpp
@@ -126,7 +126,7 @@ int ObTransformConstPropagate::ConstInfoContext::add_const_info(ExprConstInfo &c
   bool found = false;
   for (int64_t i = 0; OB_SUCC(ret) && !found && i < active_const_infos_.count(); ++i) {
     ExprConstInfo &cur_info = active_const_infos_.at(i);
-    if (const_info.column_expr_ == cur_info.const_expr_) {
+    if (const_info.column_expr_ == cur_info.column_expr_) { /* bugfix(fhkong) */
       found = true;
       if (const_info.is_used_) {
         if (OB_FAIL(expired_const_infos_.push_back(const_info))) {
@@ -141,6 +141,26 @@ int ObTransformConstPropagate::ConstInfoContext::add_const_info(ExprConstInfo &c
     }
   }
   return ret;
+}
+
+int ObTransformConstPropagate::ConstInfoContext::add_expr_info(ObRawExpr *expr)
+{
+  int ret = OB_SUCCESS;
+  bool found = false;
+  if (OB_ISNULL(expr)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("unexpected param is NULL", K(ret));
+  } else if (ObOptimizerUtil::find_item(propagate_exprs_, expr)) {
+    /* do nothing */
+  } else if (OB_FAIL(propagate_exprs_.push_back(expr))) {
+    LOG_WARN("failed to push back propagate exprs", K(ret));
+  }
+  return ret;
+}
+
+bool ObTransformConstPropagate::ConstInfoContext::is_empty() const 
+{
+  return active_const_infos_.empty() && propagate_exprs_.empty();
 }
 
 int ObTransformConstPropagate::ConstInfoContext::merge_expired_const_infos(ConstInfoContext &other,
@@ -283,7 +303,7 @@ int ObTransformConstPropagate::do_transform(ObDMLStmt *stmt,
       }
     }
 
-    if (OB_SUCC(ret) && !const_ctx.active_const_infos_.empty()) {
+    if (OB_SUCC(ret) && !const_ctx.is_empty()) {
       if (OB_FAIL(replace_common_exprs(stmt->get_condition_exprs(),
                                        const_ctx,
                                        is_happened))) {
@@ -294,7 +314,7 @@ int ObTransformConstPropagate::do_transform(ObDMLStmt *stmt,
       }
     }
 
-    if (OB_SUCC(ret) && !const_ctx.active_const_infos_.empty() &&
+    if (OB_SUCC(ret) && !const_ctx.is_empty() &&
         (stmt->is_insert_stmt() || stmt->is_merge_stmt())) {
       is_happened = false;
       ObDelUpdStmt *insert = static_cast<ObDelUpdStmt *>(stmt);
@@ -309,7 +329,7 @@ int ObTransformConstPropagate::do_transform(ObDMLStmt *stmt,
       }
     }
 
-    if (OB_SUCC(ret) && !const_ctx.active_const_infos_.empty() &&
+    if (OB_SUCC(ret) && !const_ctx.is_empty() &&
         (stmt->is_insert_stmt() || stmt->is_merge_stmt())) {
       ObDelUpdStmt *insert = static_cast<ObDelUpdStmt *>(stmt);
       if (OB_FAIL(replace_common_exprs(insert->get_sharding_conditions(),
@@ -322,7 +342,7 @@ int ObTransformConstPropagate::do_transform(ObDMLStmt *stmt,
       }
     }
 
-    if (OB_SUCC(ret) && !const_ctx.active_const_infos_.empty()) {
+    if (OB_SUCC(ret) && !const_ctx.is_empty()) {
       is_happened = false;
       if (OB_FAIL(replace_semi_conditions(stmt,
                                           const_ctx,
@@ -340,7 +360,7 @@ int ObTransformConstPropagate::do_transform(ObDMLStmt *stmt,
       has_rollup_or_groupingsets = true;
     }
 
-    if (OB_SUCC(ret) && !const_ctx.active_const_infos_.empty() && stmt->is_select_stmt() && !has_rollup_or_groupingsets) {
+    if (OB_SUCC(ret) && !const_ctx.is_empty() && stmt->is_select_stmt() && !has_rollup_or_groupingsets) {
       is_happened = false;
       if (OB_FAIL(replace_group_exprs(static_cast<ObSelectStmt*>(stmt),
                                       const_ctx,
@@ -362,7 +382,7 @@ int ObTransformConstPropagate::do_transform(ObDMLStmt *stmt,
 
 
     if (OB_SUCC(ret) && stmt->is_select_stmt()) {
-      if (!const_ctx.active_const_infos_.empty() && !ignore_all_select_exprs && static_cast<ObSelectStmt*>(stmt)->get_aggr_item_size() > 0) {
+      if (!const_ctx.is_empty() && !ignore_all_select_exprs && static_cast<ObSelectStmt*>(stmt)->get_aggr_item_size() > 0) {
         if (OB_FAIL(replace_select_exprs(static_cast<ObSelectStmt*>(stmt),
                                         const_ctx,
                                         is_happened))) {
@@ -398,7 +418,7 @@ int ObTransformConstPropagate::do_transform(ObDMLStmt *stmt,
       }
     }
 
-    if (OB_SUCC(ret) && !const_ctx.active_const_infos_.empty()) {
+    if (OB_SUCC(ret) && !const_ctx.is_empty()) {
       is_happened = false;
       if (OB_FAIL(replace_orderby_exprs(stmt->get_order_items(),
                                         const_ctx,
@@ -411,7 +431,7 @@ int ObTransformConstPropagate::do_transform(ObDMLStmt *stmt,
     }
 
     // replace select exprs using common const info and post-gby const info
-    if (OB_SUCC(ret) && !const_ctx.active_const_infos_.empty() && stmt->is_select_stmt() && !ignore_all_select_exprs) {
+    if (OB_SUCC(ret) && !const_ctx.is_empty() && stmt->is_select_stmt() && !ignore_all_select_exprs) {
       is_happened = false;
       if (static_cast<ObSelectStmt*>(stmt)->get_aggr_item_size() > 0) {
         if (OB_FAIL(replace_select_exprs_skip_agg(static_cast<ObSelectStmt*>(stmt),
@@ -433,7 +453,7 @@ int ObTransformConstPropagate::do_transform(ObDMLStmt *stmt,
     }
 
     // replace update assignment list
-    if (OB_SUCC(ret) && !const_ctx.active_const_infos_.empty() && stmt->is_update_stmt()) {
+    if (OB_SUCC(ret) && !const_ctx.is_empty() && stmt->is_update_stmt()) {
       is_happened = false;
       ObUpdateStmt *upd_stmt = static_cast<ObUpdateStmt *>(stmt);
        for (int64_t i = 0; OB_SUCC(ret) && i < upd_stmt->get_update_table_info().count(); ++i) {
@@ -453,7 +473,7 @@ int ObTransformConstPropagate::do_transform(ObDMLStmt *stmt,
     }
 
     // replace condition exprs from check constraint exprs.
-    if (OB_SUCC(ret) && !const_ctx.active_const_infos_.empty()) {
+    if (OB_SUCC(ret) && !const_ctx.is_empty()) {
       is_happened = false;
       if (OB_FAIL(replace_check_constraint_exprs(stmt,
                                                  const_ctx,
@@ -1054,14 +1074,23 @@ int ObTransformConstPropagate::replace_expr_internal(ObRawExpr *&cur_expr,
                                                      bool used_in_compare)
 {
   int ret = OB_SUCCESS;
+  trans_happened = false;
+  bool const_trans_happended = false;
+  bool expr_trans_happended = false;
   if (const_ctx.hint_allowed_trans_) {
     ObSEArray<ObRawExpr *, 8> parent_exprs;
     if (OB_FAIL(recursive_replace_expr(cur_expr,
                                       parent_exprs,
                                       const_ctx,
                                       used_in_compare,
-                                      trans_happened))) {
+                                      const_trans_happended))) {
       LOG_WARN("failed to recursive");
+    } else if (OB_FAIL(recursive_replace_case_when_expr(cur_expr, 
+                                                        const_ctx, 
+                                                        expr_trans_happended))) {
+      LOG_WARN("failed to recursive replace case when expr", K(ret));
+    } else {
+      trans_happened |= const_trans_happended || expr_trans_happended;
     }
   }
   return ret;
@@ -1164,6 +1193,138 @@ int ObTransformConstPropagate::replace_internal(ObRawExpr *&cur_expr,
       trans_happened = true;
       LOG_TRACE("succeed to replace expr", KPC(column_expr), KPC(cur_expr));
     }
+  }
+  return ret;
+}
+
+int ObTransformConstPropagate::recursive_replace_case_when_expr(ObRawExpr *&cur_expr,
+                                                                ConstInfoContext &const_ctx,
+                                                                bool &trans_happended) 
+{
+  int ret = OB_SUCCESS;
+  trans_happended = false;
+  bool is_shared = false;
+  bool is_happended = false;
+  if (OB_ISNULL(cur_expr))  {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("unexpected param is NULL", K(ret));
+  } else if (OB_FAIL(const_ctx.shared_expr_checker_.is_shared_expr(cur_expr, is_shared))) {
+    LOG_WARN("failed to check lis shared expr", K(ret));
+  } else if (is_shared) {
+    /* do nothing for shared expr */
+  } else if (OB_FAIL(replace_case_when_expr_internal(cur_expr,
+                                                     const_ctx,
+                                                     is_happended))) {
+    LOG_WARN("failed to replace case when expr internal", K(ret)); 
+  } else {
+    trans_happended |= is_happended;
+    int64_t N = cur_expr->get_param_count();
+    for (int64_t i = 0; OB_SUCC(ret) && i < N; ++i) {
+      bool param_trans_happended = false;
+      ObRawExpr *&child_expr = cur_expr->get_param_expr(i);
+      if (OB_FAIL(SMART_CALL(recursive_replace_case_when_expr(child_expr, 
+                                                              const_ctx, 
+                                                              param_trans_happended)))) {
+        LOG_WARN("failed to recursive replace case when expr", K(ret));
+      } else {
+        trans_happended |= param_trans_happended;
+      }
+    } 
+  }
+  return ret;
+}
+
+int ObTransformConstPropagate::replace_case_when_expr_internal(ObRawExpr *&cur_expr,
+                                                               ConstInfoContext &const_ctx,
+                                                               bool &trans_happended) 
+{
+  int ret = OB_SUCCESS;
+  trans_happended = false;
+  ObCaseOpRawExpr *case_expr = NULL;
+  if (OB_ISNULL(cur_expr)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("invalid param", K(ret));
+  } else if (T_OP_CASE != cur_expr->get_expr_type()) {
+    /* do nothing */
+  } else if (OB_FALSE_IT(case_expr = static_cast<ObCaseOpRawExpr*>(cur_expr))) {
+  } else if (OB_UNLIKELY(case_expr->get_when_expr_size() != case_expr->get_then_expr_size())) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("incorrect param in case expr", K(ret), 
+                      K(case_expr->get_when_expr_size()),
+                      K(case_expr->get_then_expr_size()));
+  } else if (OB_UNLIKELY(case_expr->get_when_expr_size() <= 0)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("incorrect param in case expr", K(ret));
+  } else {
+    for (int64_t i = 0; OB_SUCC(ret) && i < case_expr->get_when_expr_size(); ++i) {
+      bool param_trans_happended = false;
+      if (OB_FAIL(recursive_replace_when_expr(case_expr->get_when_param_expr(i), 
+                                              const_ctx, 
+                                              param_trans_happended))) {
+        LOG_WARN("failed to replace case when expr", K(ret));
+      } else {
+        trans_happended |= param_trans_happended;
+      }
+    } 
+  }
+  return ret;
+}
+
+
+int ObTransformConstPropagate::recursive_replace_when_expr(ObRawExpr *&when_expr,
+                                                           ConstInfoContext &const_ctx,
+                                                           bool &trans_happended) 
+{
+  int ret = OB_SUCCESS;
+  trans_happended = false; 
+  bool is_happended = false;
+  if (OB_ISNULL(when_expr)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("invalid parameter", K(ret));
+  } else if (OB_FAIL(replace_when_expr_internal(when_expr, 
+                                                const_ctx.propagate_exprs_, 
+                                                is_happended))) {
+    LOG_WARN("failed to replace when expr internal", K(ret));
+  } else if (!is_happended) {
+    bool is_shared = false; // if this is shared_expr, we shouldn't replace its children exprs
+    if (OB_FAIL(const_ctx.shared_expr_checker_.is_shared_expr(when_expr, is_shared))) {
+      LOG_WARN("failed to check is shared expr", K(ret)); 
+    } else if (is_shared) {
+      /* do nothing */
+    } else if (when_expr->get_param_count() > 0) {
+      int64_t N = when_expr->get_param_count();
+      for (int64_t i = 0; OB_SUCC(ret) && i < N; ++i) {
+        bool param_trans_happended = false;
+        if (OB_FAIL(SMART_CALL(recursive_replace_when_expr(when_expr->get_param_expr(i),
+                                                           const_ctx,
+                                                           param_trans_happended)))) {
+          LOG_WARN("failed to recusive replace when expr", K(ret));
+        } else {
+          trans_happended |= param_trans_happended;
+        }
+      }
+    }
+  } else {
+    trans_happended |= is_happended;
+  }
+  return ret;
+}
+
+int ObTransformConstPropagate::replace_when_expr_internal(ObRawExpr *&when_expr,
+                                                          ObIArray<ObRawExpr *> &propagate_exprs,
+                                                          bool &trans_happended) 
+{
+  int ret = OB_SUCCESS;
+  trans_happended = false;
+  if (OB_ISNULL(when_expr)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("unexpected param is NULL", K(ret));
+  } else if (!ObOptimizerUtil::find_item(propagate_exprs, when_expr)) {
+    /* do nothing */
+  } else if (OB_FAIL(replace_with_true_expr(when_expr))) {
+    LOG_WARN("failed to replace expr with true_expr", K(ret));
+  } else {
+    trans_happended = true;
   }
   return ret;
 }
@@ -1797,6 +1958,8 @@ int ObTransformConstPropagate::recursive_collect_equal_pair_from_condition(ObDML
   if (OB_ISNULL(stmt) || OB_ISNULL(expr)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("get unexpected null", K(ret), K(stmt), K(expr));
+  } else if (OB_FAIL(const_ctx.add_expr_info(expr))) {
+    LOG_WARN("failed to add propagate expr", K(ret));
   } else if (T_OP_EQ == expr->get_expr_type()) {
     // todo: support general expr const info instead of column expr
     ObRawExpr *param_1 = expr->get_param_expr(0);
@@ -1841,7 +2004,7 @@ int ObTransformConstPropagate::recursive_collect_equal_pair_from_condition(ObDML
       if (OB_FAIL(SMART_CALL(recursive_collect_equal_pair_from_condition(stmt,
                                                                          expr->get_param_expr(i),
                                                                          const_ctx,
-                                                                         trans_happened)))) {
+                                                                         is_happened)))) { /* bugfix(fhkong) */
         LOG_WARN("failed to recursive collect const info from condition", K(ret));
       } else {
         trans_happened |= is_happened;
@@ -2582,6 +2745,26 @@ int ObTransformConstPropagate::replace_select_exprs_skip_agg_internal(ObRawExpr 
     if (OB_SUCC(ret)) {
       parent_exprs.pop_back();
     }
+  }
+  return ret;
+}
+
+int ObTransformConstPropagate::replace_with_true_expr(ObRawExpr *&expr) {
+  int ret = OB_SUCCESS;
+  if (OB_ISNULL(true_expr_)) {
+    if (OB_ISNULL(ctx_)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("unexpected param is NULL", K(ret));
+    } else if (OB_FAIL(ObRawExprUtils::build_const_bool_expr(ctx_->expr_factory_, 
+                                                             true_expr_, true))) {
+      LOG_WARN("failed to build bool expr");
+    } else if (OB_ISNULL(true_expr_)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("unexpected param is NULL", K(ret));
+    }
+  }
+  if (OB_SUCC(ret)) {
+    expr = true_expr_;
   }
   return ret;
 }

--- a/src/sql/rewrite/ob_transform_const_propagate.h
+++ b/src/sql/rewrite/ob_transform_const_propagate.h
@@ -26,7 +26,7 @@ class ObTransformConstPropagate : public ObTransformRule
 public:
   explicit ObTransformConstPropagate(ObTransformerCtx *ctx) : 
     ObTransformRule(ctx, TransMethod::POST_ORDER, T_REPLACE_CONST),
-    allocator_("ConstPropagate") {}
+    allocator_("ConstPropagate"), true_expr_(NULL) {}
 
   virtual ~ObTransformConstPropagate();
 
@@ -94,6 +94,7 @@ private:
                      bool hint_allowed_trans) : active_const_infos_(),
                          expired_const_infos_(),
                          extra_excluded_exprs_(),
+                         propagate_exprs_(),
                          hint_allowed_trans_(hint_allowed_trans),
                          shared_expr_checker_(shared_expr_checker)
     {
@@ -102,19 +103,23 @@ private:
 
     int add_const_infos(ObIArray<ExprConstInfo> &const_infos);
     int add_const_info(ExprConstInfo &const_info);
+    int add_expr_info(ObRawExpr *expr);
     int merge_expired_const_infos(ConstInfoContext &other, bool is_null_side);
     int find_exclude_expr(const ObRawExpr *expr, bool &found);
     int expire_const_infos();
+    bool is_empty() const;
 
     common::ObSEArray<ExprConstInfo, 4> active_const_infos_;
     common::ObSEArray<ExprConstInfo, 4> expired_const_infos_;
     common::ObSEArray<ObRawExpr *, 4> extra_excluded_exprs_;
+    common::ObSEArray<ObRawExpr *, 4> propagate_exprs_;
     bool hint_allowed_trans_;
     const ObSharedExprChecker &shared_expr_checker_;
 
     TO_STRING_KV(K_(active_const_infos),
                  K_(expired_const_infos),
                  K_(extra_excluded_exprs),
+                 K_(propagate_exprs),
                  K_(hint_allowed_trans));
   };
 
@@ -263,6 +268,19 @@ private:
                        bool used_in_compare,
                        bool &trans_happened);
 
+  int recursive_replace_case_when_expr(ObRawExpr *&cur_expr, 
+                                       ConstInfoContext &const_ctx,
+                                       bool &trans_happended);
+  int replace_case_when_expr_internal(ObRawExpr *&cur_expr,
+                                      ConstInfoContext &const_ctx,
+                                      bool &trans_happended);
+  int recursive_replace_when_expr(ObRawExpr *&when_expr, 
+                                  ConstInfoContext &const_ctx,
+                                  bool &trans_happended);
+  int replace_when_expr_internal(ObRawExpr *&when_expr,
+                                ObIArray<ObRawExpr *> &propagate_exprs,
+                                bool &trans_happended);
+
   int prepare_new_expr(ExprConstInfo &const_info);
 
   int check_set_op_expr_const(ObSelectStmt *stmt,
@@ -364,11 +382,13 @@ private:
                                       ObRawExpr *expr,
                                       ExprConstInfo &equal_info);
 
+  int replace_with_true_expr(ObRawExpr *&expr);
 private:
   typedef ObSEArray<PullupConstInfo, 2> PullupConstInfos;
   ObArenaAllocator allocator_;
   hash::ObHashMap<uint64_t, int64_t> stmt_map_;
   ObSEArray<PullupConstInfos *, 4> stmt_pullup_const_infos_;
+  ObRawExpr *true_expr_;
 };
 
 } //namespace sql

--- a/src/sql/rewrite/ob_transform_const_propagate.h
+++ b/src/sql/rewrite/ob_transform_const_propagate.h
@@ -95,6 +95,7 @@ private:
                          expired_const_infos_(),
                          extra_excluded_exprs_(),
                          propagate_exprs_(),
+                         need_propagate_exprs_(true),
                          hint_allowed_trans_(hint_allowed_trans),
                          shared_expr_checker_(shared_expr_checker)
     {
@@ -113,6 +114,7 @@ private:
     common::ObSEArray<ExprConstInfo, 4> expired_const_infos_;
     common::ObSEArray<ObRawExpr *, 4> extra_excluded_exprs_;
     common::ObSEArray<ObRawExpr *, 4> propagate_exprs_;
+    bool need_propagate_exprs_;
     bool hint_allowed_trans_;
     const ObSharedExprChecker &shared_expr_checker_;
 


### PR DESCRIPTION
### Task Description
某些情况下，表达式会出现冗余判断，我们希望借助于先验的表达式集合来消除这种冗余判断。例如下列SQL：

select 1 from t1 where c1 > c2 and case when c1 > c2 then c1 else c2 end > 1
由于c1 > c2在case when表达式之前已经判断过，导致case when中的c1 > c2表达式为恒真；对于这种情况，我们可以将case when表达式消除掉。
得到最终的SQL语句

select 1 from t1 where c1 > c2 and c1 > 1

### Solution Description
借助于常量传播的代码框架，实现表达式传播。方案的关键是：为每个表达式正确地找到作用域，并在其作用域内进行传播。
主要步骤为：

找到会产生新的作用域的情况。
在每个作用域内抽取表达式，并在离开作用域时，对该作用域进行传播。
判断目标表达式 E 是否可以被改写（规避共享表达式、连接条件表达式）。
子作用域的表达式不能传播到父层，但父作用域可以传播到子层。

### Passed Regressions
已有testcase：transformer_const_propagate.test
自测testcase：transformer_expr_propagate.test

### Upgrade Compatibility
None

### Other Information

None
### Release Note
None
