### PR TITLE
use zone map optimize paging query

### DIFF
--- a/src/sql/code_generator/ob_static_engine_cg.cpp
+++ b/src/sql/code_generator/ob_static_engine_cg.cpp
@@ -1731,6 +1731,13 @@ int ObStaticEngineCG::generate_spec(ObLogSort &op, ObSortSpec &spec, const bool 
       if (OB_NOT_NULL(spec.topn_expr_) && !ob_is_integer_type(spec.topn_expr_->datum_meta_.type_)) {
         ret = OB_ERR_UNEXPECTED;
         LOG_WARN("topn must be int", K(ret), K(*spec.topn_expr_));
+      } else if (OB_NOT_NULL(op.get_topn_offset_expr())) {
+        OZ(generate_rt_expr(*op.get_topn_offset_expr(), spec.topn_offset_expr_));
+        if (OB_NOT_NULL(spec.topn_offset_expr_)
+            && !ob_is_integer_type(spec.topn_offset_expr_->datum_meta_.type_)) {
+          ret = OB_ERR_UNEXPECTED;
+          LOG_WARN("offset must be int", K(ret), K(*spec.topn_offset_expr_));
+        }
       }
     }
     if (OB_NOT_NULL(op.get_topk_limit_expr())) {

--- a/src/sql/engine/sort/ob_sort_op.h
+++ b/src/sql/engine/sort/ob_sort_op.h
@@ -31,11 +31,12 @@ public:
   ObSortSpec(common::ObIAllocator &alloc, const ObPhyOperatorType type);
 
   INHERIT_TO_STRING_KV("op_spec", ObOpSpec,
-    K_(topn_expr), K_(topk_limit_expr), K_(topk_offset_expr), K_(prefix_pos),
+    K_(topn_expr), K_(topn_offset_expr), K_(topk_limit_expr), K_(topk_offset_expr), K_(prefix_pos),
     K_(minimum_row_count), K_(topk_precision), K_(prefix_pos), K_(is_local_merge_sort),
     K_(prescan_enabled), K_(enable_encode_sortkey_opt), K_(part_cnt));
 public:
   ObExpr *topn_expr_;
+  ObExpr *topn_offset_expr_;
   ObExpr *topk_limit_expr_;
   ObExpr *topk_offset_expr_;
   // sort exprs + output_exprs
@@ -114,7 +115,7 @@ private:
   }
 
   int get_int_value(const ObExpr *in_val, int64_t &out_val);
-  int get_topn_count(int64_t &topn_cnt);
+  int get_topn_count(int64_t &topn_cnt, int64_t &topn_offset);
   int process_sort();
   int process_sort_batch();
   int scan_all_then_sort();
@@ -126,7 +127,8 @@ private:
   int init_sort(int64_t tenant_id,
                 int64_t row_count,
                 bool is_batch,
-                int64_t topn_cnt = INT64_MAX);
+                int64_t topn_cnt = INT64_MAX,
+                int64_t offset = 0);
 private:
   ObSortOpImpl sort_impl_;
   ObPrefixSortImpl prefix_sort_impl_;

--- a/src/sql/optimizer/ob_log_plan.h
+++ b/src/sql/optimizer/ob_log_plan.h
@@ -805,6 +805,7 @@ public:
 
   int get_order_by_topn_expr(int64_t input_card,
                              ObRawExpr *&topn_expr,
+                             ObRawExpr *&offset_expr,
                              bool &is_fetch_with_ties,
                              bool &need_limit);
 
@@ -827,6 +828,7 @@ public:
   int create_order_by_plan(ObLogicalOperator *&top,
                            const ObIArray<OrderItem> &order_items,
                            ObRawExpr *topn_expr,
+                           ObRawExpr *offset_expr,
                            bool is_fetch_with_ties);
 
   int allocate_sort_and_exchange_as_top(ObLogicalOperator *&top,
@@ -836,6 +838,7 @@ public:
                                         const int64_t prefix_pos,
                                         const bool is_local_order,
                                         ObRawExpr *topn_expr = NULL,
+                                        ObRawExpr *offset_expr = NULL,
                                         bool is_fetch_with_ties = false,
                                         const OrderItem *hash_sortkey = NULL);
 
@@ -855,6 +858,7 @@ public:
                            const int64_t prefix_pos = 0,
                            const bool is_local_merge_sort = false,
                            ObRawExpr *topn_expr = NULL,
+                           ObRawExpr *offset_expr = NULL,
                            bool is_fetch_with_ties = false,
                            const OrderItem *hash_sortkey = NULL);
 

--- a/src/sql/optimizer/ob_log_sort.h
+++ b/src/sql/optimizer/ob_log_sort.h
@@ -30,6 +30,7 @@ namespace sql
           sort_keys_(),
           encode_sortkeys_(),
           topn_expr_(NULL),
+          topn_offset_expr_(NULL),
           minimum_row_count_(0),
           topk_precision_(0),
           prefix_pos_(0),
@@ -57,6 +58,7 @@ namespace sql
     int get_sort_exprs(common::ObIArray<ObRawExpr*> &sort_exprs);
 
     inline void set_topn_expr(ObRawExpr *expr) { topn_expr_ = expr; }
+    inline void set_topn_offset_expr(ObRawExpr *expr) { topn_offset_expr_ = expr; }
     inline void set_prefix_pos(int64_t prefix_pos) { prefix_pos_ = prefix_pos; }
     inline void set_local_merge_sort(bool is_local_merge_sort) { is_local_merge_sort_ = is_local_merge_sort; }
     inline void set_fetch_with_ties(bool is_fetch_with_ties) { is_fetch_with_ties_ = is_fetch_with_ties; }
@@ -71,6 +73,7 @@ namespace sql
     inline int64_t get_part_cnt() const { return part_cnt_; }
     inline int64_t get_prefix_pos() const { return prefix_pos_; }
     inline ObRawExpr *get_topn_expr() const { return topn_expr_; }
+    inline ObRawExpr *get_topn_offset_expr() const { return topn_offset_expr_; }
     inline void set_topk_limit_expr(ObRawExpr *top_limit_expr)
     {
       topk_limit_expr_ = top_limit_expr;
@@ -107,6 +110,7 @@ namespace sql
     common::ObSEArray<OrderItem, 8, common::ModulePageAllocator, true> sort_keys_;
     common::ObSEArray<OrderItem, 1, common::ModulePageAllocator, true> encode_sortkeys_;
     ObRawExpr *topn_expr_;
+    ObRawExpr *topn_offset_expr_;
     int64_t minimum_row_count_;
     int64_t topk_precision_;
     int64_t prefix_pos_; //  for prefix_sort

--- a/src/sql/optimizer/ob_select_log_plan.cpp
+++ b/src/sql/optimizer/ob_select_log_plan.cpp
@@ -1114,6 +1114,7 @@ int ObSelectLogPlan::inner_create_merge_group_plan(const ObIArray<ObRawExpr*> &r
                                               top_is_local_order ? 0 : prefix_pos,
                                               !need_sort && top_is_local_order,
                                               nullptr,
+                                              nullptr,
                                               is_fetch_with_ties,
                                               use_part_sort ? &hash_sortkey : NULL))) {
         LOG_WARN("failed to allcoate sort as top", K(ret));
@@ -1151,6 +1152,7 @@ int ObSelectLogPlan::inner_create_merge_group_plan(const ObIArray<ObRawExpr*> &r
                                                            need_sort,
                                                            prefix_pos,
                                                            top->get_is_local_order(),
+                                                           nullptr,
                                                            nullptr,
                                                            is_fetch_with_ties,
                                                            use_part_sort ? &hash_sortkey : NULL))) {
@@ -5981,6 +5983,7 @@ int ObSelectLogPlan::create_none_dist_win_func(ObLogicalOperator *top,
     } else if (OB_FAIL(allocate_sort_and_exchange_as_top(hash_sort_top, exch_info, sort_keys, need_sort,
                                                          prefix_pos, is_local_order,
                                                          NULL, /* topn_expr */
+                                                         NULL, /* offset_expr */
                                                          false, /* is_fetch_with_ties */
                                                          &hash_sortkey))) {
       LOG_WARN("failed to allocate sort and exchange as top", K(ret));
@@ -6262,6 +6265,7 @@ int ObSelectLogPlan::create_normal_hash_dist_win_func(ObLogicalOperator *&top,
                                                       prefix_pos,
                                                       top->get_is_local_order(),
                                                       NULL, /* topn_expr */
+                                                      NULL, /* offset_expr */
                                                       false, /* is_fetch_with_ties */
                                                       hash_sortkey))) {
     LOG_WARN("failed to allocate sort and exchange as top", K(ret));
@@ -6301,6 +6305,7 @@ int ObSelectLogPlan::create_pushdown_hash_dist_win_func(ObLogicalOperator *&top,
                                              sort_keys,
                                              need_sort && !top_is_local_order ? prefix_pos : 0,
                                              need_sort ? false : top_is_local_order,
+                                             NULL,
                                              NULL,
                                              false, // is_fetch_with_ties
                                              hash_sortkey))) {


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase**! 
Please read the [How to Contribute](https://github.com/oceanbase/oceanbase/wiki/how_to_contribute) document **BEFORE** filling this PR.

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description
close #1540 

use Zone Map to optimize paging query.

This optimization can reduce the amount of data that needs to be sorted in paging query.

### Solution Description

In memory, meta information (row count, maximum row, minimum row) is maintained for each dump file, and then the amount of data that needs to be read is reduced.

### Passed Regressions

pass tests in ob repo

### Upgrade Compatibility

This optimization is orthogonal to the implementation of Sort/Limit,  so it's easy to integrate this optimization.

### Release Note

This optimization speed up in ordered/semi-ordered scenarios.