### PR TITLE
ObSQL Audit 无锁队列扩缩容

### DIFF
--- a/src/observer/CMakeLists.txt
+++ b/src/observer/CMakeLists.txt
@@ -72,6 +72,7 @@ ob_set_subtarget(ob_server mysql
   mysql/ob_query_retry_ctrl.cpp
   mysql/ob_sync_cmd_driver.cpp
   mysql/ob_sync_plan_driver.cpp
+  mysql/ob_tl_queue.cpp
   mysql/obmp_base.cpp
   mysql/obmp_change_user.cpp
   mysql/obmp_connect.cpp

--- a/src/observer/mysql/ob_mysql_request_manager.h
+++ b/src/observer/mysql/ob_mysql_request_manager.h
@@ -77,9 +77,9 @@ public:
   static const int64_t US_PER_HOUR = 3600000000;
   //初始化queue大小，常规模式1000w，mini模式10w
   // static const int64_t MAX_QUEUE_SIZE = 10000000; //1000w
-  static const int64_t MAX_QUEUE_CAPACITY = 1024; // 1K
-  static const int64_t SUBQUEUE_CAPACITY = 10000; // 1w
-  static const int64_t MINI_SUBQUEUE_CAPACITY = 1000; // 1k
+  static const int64_t MAX_QUEUE_CAPACITY = 10000; // 1w
+  static const int64_t SUBQUEUE_CAPACITY = 1000; // 1k
+  static const int64_t MINI_SUBQUEUE_CAPACITY = 100; // 100
   // static const int64_t MINI_MODE_MAX_QUEUE_SIZE = 100000; // 10w
   //按行淘汰的高低水位线，以queue大小的百分比设定
   static constexpr float HIGH_LEVEL_EVICT_PERCENTAGE = 0.9; // 90%

--- a/src/observer/mysql/ob_tl_queue.cpp
+++ b/src/observer/mysql/ob_tl_queue.cpp
@@ -1,0 +1,255 @@
+/**
+ * Copyright (c) 2021 OceanBase
+ * OceanBase CE is licensed under Mulan PubL v2.
+ * You can use this software according to the terms and conditions of the Mulan PubL v2.
+ * You may obtain a copy of Mulan PubL v2 at:
+ *          http://license.coscl.org.cn/MulanPubL-2.0
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PubL v2 for more details.
+ */
+
+#define USING_LOG_PREFIX SERVER
+
+#include "observer/mysql/ob_tl_queue.h"
+#include <iostream>
+
+namespace oceanbase {
+namespace common {
+int ObTLQueue::ObSubQueue::init(const char *label, uint64_t capacity,
+                                uint64_t tenant_id) {
+  int ret = OB_SUCCESS;
+  ObMemAttr mem_attr;
+  mem_attr.label_ = label;
+  mem_attr.tenant_id_ = tenant_id;
+  if (capacity <= 0) {
+    ret = OB_INVALID_ARGUMENT;
+  } else if (OB_ISNULL(array_ = (void **)ob_malloc(sizeof(void *) * capacity,
+                                                   mem_attr))) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+  } else {
+    memset(array_, 0, sizeof(void *) * capacity);
+    next_ = 0;
+    capacity_ = capacity;
+  }
+  return ret;
+}
+
+void ObTLQueue::ObSubQueue::destroy(ObConcurrentFIFOAllocator *allocator) {
+  if (OB_ISNULL(array_)) {
+  } else if(OB_ISNULL(allocator)) {
+  } else {
+    void *p = NULL;
+    uint64_t idx = 0;
+    while (idx < next_) {
+      if (OB_NOT_NULL(p = array_[idx++])) {
+        allocator->free(p);
+        p = NULL;
+      }
+    }
+    ob_free(array_);
+    array_ = NULL;
+  }
+}
+
+int ObTLQueue::ObSubQueue::push(void *p, int64_t &seq) {
+  int ret = OB_SUCCESS;
+  if (NULL == array_) {
+    ret = OB_NOT_INIT;
+  } else if (NULL == p) {
+    ret = OB_INVALID_ARGUMENT;
+  } else {
+    uint64_t next = ATOMIC_LOAD(&next_);
+    uint64_t ov = next;
+    while ((ov = next) < capacity_ &&
+           ov != (next = ATOMIC_VCAS(&next_, ov, ov + 1))) {
+      ;
+    }
+    if (next >= capacity_) {
+      ret = OB_ENTRY_NOT_EXIST;
+    } else {
+      array_[next] = p;
+      seq = next;
+    }
+  }
+  return ret;
+}
+
+void *ObTLQueue::ObSubQueue::get(uint64_t idx) {
+  void *p = NULL;
+  if (NULL == array_) {
+  } else if (idx >= capacity_) {
+  } else {
+    p = array_[idx];
+  }
+  return p;
+}
+
+int ObTLQueue::init(const char *label, uint64_t capacity, uint64_t subcapacity,
+                    ObConcurrentFIFOAllocator *allocator, uint64_t tenant_id) {
+  int ret = OB_SUCCESS;
+  ObMemAttr mem_attr;
+  mem_attr.label_ = label;
+  mem_attr.tenant_id_ = tenant_id;
+  if (capacity <= 0) {
+    ret = OB_INVALID_ARGUMENT;
+  } else if (OB_ISNULL(array_ = (ObSubQueue **)ob_malloc(
+                           sizeof(ObSubQueue *) * capacity, mem_attr))) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+  } else if (OB_ISNULL(ref_ = (int64_t *)ob_malloc(sizeof(int64_t) * capacity,
+                                                   mem_attr))) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+  } else {
+    memset(ref_, 0, sizeof(int64_t) * capacity);
+    memset(array_, 0, sizeof(ObSubQueue *) * capacity);
+    capacity_ = capacity;
+    subcapacity_ = subcapacity;
+    mem_label_ = label;
+    tenant_id_ = tenant_id;
+    allocator_ = allocator;
+    for (uint64_t i = 0; OB_SUCC(ret) && i < QUEUE_POOL_SIZE; ++i) {
+      if (OB_ISNULL(queue_pool_[i] = (ObSubQueue *)ob_malloc(sizeof(ObSubQueue),
+                                                             mem_attr))) {
+        ret = OB_ALLOCATE_MEMORY_FAILED;
+      } else if (OB_FAIL(
+                     queue_pool_[i]->init(label, subcapacity_, tenant_id_))) {
+        /* do nothing */
+      }
+    }
+  }
+  return ret;
+}
+
+int ObTLQueue::push_with_retry(void *p, int64_t &seq) {
+  int ret = OB_SUCCESS;
+  while (OB_ENTRY_NOT_EXIST == (ret = push(p, seq))) {
+    ;
+  }
+  return ret;
+}
+int ObTLQueue::push(void *p, int64_t &seq) {
+  int ret = OB_SUCCESS;
+  if (NULL == array_) {
+    ret = OB_NOT_INIT;
+  } else if (NULL == p) {
+    ret = OB_INVALID_ARGUMENT;
+  } else {
+    uint64_t pop = get_pop_idx();
+    uint64_t push = get_push_idx();
+    // 外层队列已满
+    if (push >= pop + capacity_) {
+      ret = OB_SIZE_OVERFLOW;
+    } else {
+      ObSubQueue **subq_addr = get_subq_addr(push);
+      ObSubQueue *subq = NULL;
+      while ((ObSubQueue *)LOCK ==
+             (subq = ATOMIC_VCAS(subq_addr, NULL, (ObSubQueue *)LOCK))) {
+      }
+      // 该线程首先进入需要申请内存
+      if (OB_ISNULL(subq)) {
+        // todo(fhkong): 后面将malloc and init操作替换为 memory pool;
+        // fixed(fhkong): queue_pool 操作需要上锁
+        ObMemAttr mem_attr;
+        mem_attr.label_ = mem_label_;
+        mem_attr.tenant_id_ = tenant_id_;
+        if (NULL != (subq = get_subq_from_pool())) {
+        } else if (OB_ISNULL(subq = (ObSubQueue *)ob_malloc(sizeof(ObSubQueue), mem_attr))) {
+          ret = OB_ALLOCATE_MEMORY_FAILED;
+        } else if (OB_FAIL(subq->init(mem_label_, subcapacity_, tenant_id_))) {
+          ret = OB_NOT_INIT;
+        }
+        ATOMIC_STORE(subq_addr, subq);
+      }
+      // 多个线程同时插入一个subq
+      int64_t subseq = 0;
+      xref(push, 1);
+      if (OB_SUCC(subq->push(p, subseq))) {
+        seq = push * subcapacity_ + subseq;
+      } else {
+        // 插入失败, head++, 重新尝试插入
+        ATOMIC_BCAS(&push_, push, push + 1);
+      }
+      xref(push, -1);
+    }
+  }
+  return ret;
+}
+
+int ObTLQueue::pop_batch() {
+  int ret = OB_SUCCESS;
+  if (NULL == array_) {
+    ret = OB_NOT_INIT;
+  } else {
+    uint64_t pop_limit = 0;
+    uint64_t pop = faa_bounded(&pop_, &push_, pop_limit);
+    if (pop <= pop_limit) {
+      ObSubQueue **subq_addr = get_subq_addr(pop);
+      ObSubQueue *subq = NULL;
+      while (NULL != (subq = ATOMIC_LOAD(subq_addr)) && 
+            (LOCK == (uint64_t)subq || !ATOMIC_BCAS(subq_addr, subq, NULL))) {
+      }
+      if (OB_ISNULL(subq)) {
+        ret = OB_ENTRY_NOT_EXIST;
+      } else {
+        wait_ref_clear(pop);
+        subq->destroy(allocator_);
+        ob_free(subq);
+      }
+    }
+  }
+  return ret;
+}
+
+void *ObTLQueue::get(uint64_t idx, Ref *ref) {
+  void *ret = NULL;
+  ObSubQueue *subq = NULL;
+  if (OB_ISNULL(array_)) {
+  } else {
+    uint64_t fidx = idx / subcapacity_;
+    uint64_t sidx = idx % subcapacity_;
+    ObSubQueue **subq_addr = get_subq_addr(fidx);
+    while (LOCK ==
+           (uint64_t)(subq = ATOMIC_TAS(subq_addr, (ObSubQueue *)LOCK))) {
+    }
+    if (NULL == subq) {
+      ATOMIC_STORE(subq_addr, NULL);
+    } else {
+      xref(fidx, 1);
+      ATOMIC_STORE(subq_addr, subq);
+      ret = subq->get(sidx);
+      ref->set(idx, ret);
+    }
+  }
+  return ret;
+}
+
+void ObTLQueue::destroy() {
+  // free queue_pool_
+  for (uint64_t i = 0; i < QUEUE_POOL_SIZE; ++i) {
+    if (NULL != queue_pool_[i]) {
+      queue_pool_[i]->destroy(allocator_);
+      ob_free(queue_pool_[i]);
+      queue_pool_[i] = NULL;
+    }
+  }
+  if (NULL != array_) {
+    ObSubQueue *subq = NULL;
+    while (pop_ <= push_) {
+      if (OB_ISNULL(subq = array_[idx(pop_++)])) {
+      } else {
+        subq->destroy(allocator_);
+        ob_free(subq);
+        subq = NULL;
+      }
+    }
+    ob_free(array_);
+    array_ = NULL;
+  }
+  if (NULL != ref_) {
+    ob_free(ref_);
+    ref_ = NULL;
+  }
+}
+}; // end namespace common
+}; // end namespace oceanbase

--- a/src/observer/mysql/ob_tl_queue.h
+++ b/src/observer/mysql/ob_tl_queue.h
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2021 OceanBase
+ * OceanBase CE is licensed under Mulan PubL v2.
+ * You can use this software according to the terms and conditions of the Mulan PubL v2.
+ * You may obtain a copy of Mulan PubL v2 at:
+ *          http://license.coscl.org.cn/MulanPubL-2.0
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PubL v2 for more details.
+ */
+
+#ifndef OCEANBASE_MYSQL_OB_TL_QUEUE_H_
+#define OCEANBASE_MYSQL_OB_TL_QUEUE_H_
+
+#include "lib/allocator/ob_allocator.h"
+#include "lib/allocator/ob_concurrent_fifo_allocator.h"
+#include "share/ob_define.h"
+#include "observer/mysql/ob_ra_queue.h" // use ObRaQueue::Ref
+
+namespace oceanbase
+{
+namespace common
+{
+using Ref = ObRaQueue::Ref;
+/**
+ * Two-Level Queue supports:
+ *  1. dynamic increase and shrink of memory.
+ *  2. high concurrency and thread safety.
+*/
+class ObTLQueue {
+ private:
+  class ObSubQueue {
+   public:
+    ObSubQueue() : next_(0), capacity_(0), array_(nullptr) {}
+    int init(const char *label, uint64_t capacity, uint64_t tenant_id);
+    // note(fhkong): 上层保证 destroy 一定只有一个线程操作
+    void destroy(ObConcurrentFIFOAllocator *allocator);
+    // 多个生产者
+    int push(void *p, int64_t &seq);
+    // note(fhkong): get之前首先在外层将ref++
+    void *get(uint64_t idx);
+    uint64_t get_next_idx() { return ATOMIC_LOAD(&next_); }
+
+   private:
+    uint64_t next_;
+    uint64_t capacity_;
+    void **array_;
+  }; /* end define ObSubQueue */
+
+ public:
+  static constexpr uint64_t LOCK = ~0LL;
+  static constexpr uint64_t QUEUE_POOL_SIZE = 5;
+  ObTLQueue()
+      : pop_(0), push_(0), capacity_(0), subcapacity_(0), mem_label_(NULL),
+        ref_(NULL), array_(NULL) {
+    memset(queue_pool_, 0, sizeof(ObSubQueue *) * QUEUE_POOL_SIZE);
+  };
+  ~ObTLQueue() { destroy(); };
+  int init(const char *label, uint64_t capacity, uint64_t subcapacity,
+           ObConcurrentFIFOAllocator *allocator = NULL, 
+           uint64_t tenant_id = OB_INVALID_TENANT_ID);
+  // 插入失败表明当前二级队列已满，需要 retry
+  int push_with_retry(void *p, int64_t &seq);
+  int push(void *p, int64_t &seq);
+
+  /* 1. ref为0的时候才允许pop
+  *  2. 后台单线程pop 
+  *  3. 允许pop正在push的二级队列 */
+  int pop_batch();
+  void *get(uint64_t idx, Ref *ref);
+  void destroy();
+  uint64_t get_head_idx() const { return get_pop_idx() * subcapacity_; }
+  uint64_t get_tail_idx() const {
+    uint64_t pop = get_pop_idx();
+    uint64_t push = get_push_idx();
+    return push * subcapacity_ + (push < pop + capacity_ ? get_subq_size(push) : 0);
+  }
+  uint64_t get_size() const {
+    return get_tail_idx() - get_head_idx();
+  }
+
+  uint64_t get_alloc() const {
+    uint64_t pop = get_pop_idx();
+    uint64_t push = get_push_idx();
+    return (push - pop) * subcapacity_ + 
+       ((push < pop + capacity_ && get_subq_size(push)) > 0 ? subcapacity_ : 0);
+  }
+
+  uint64_t get_capacity() const {
+    return capacity_ * subcapacity_;
+  }
+  void revert(Ref *ref) {
+    if (NULL != ref) {
+      xref(ref->idx_ / subcapacity_, -1);
+      ref->reset();
+    }
+  }
+
+ private:
+  uint64_t get_pop_idx() const { return ATOMIC_LOAD(&pop_); }
+  uint64_t get_push_idx() const { return ATOMIC_LOAD(&push_); }
+  ObSubQueue **get_subq_addr(uint64_t x) { return array_ + idx(x); }
+  uint64_t idx(uint64_t x) const { return x % capacity_; }
+  uint64_t faa_bounded(uint64_t *addr, uint64_t *limit_addr, uint64_t &limit) {
+    uint64_t val = ATOMIC_LOAD(addr);
+    uint64_t ov = 0;
+    limit = ATOMIC_LOAD(limit_addr);
+    while (((ov = val) < limit || val < (limit = ATOMIC_LOAD(limit_addr))) &&
+           ov != (val = ATOMIC_VCAS(addr, ov, ov + 1))) {
+      PAUSE();
+    }
+    return val;
+  }
+  void wait_ref_clear(int64_t x) {
+    while (0 != ATOMIC_LOAD(ref_ + idx(x))) {
+      usleep(1000);
+    }
+  }
+  int64_t xref(int64_t x, int64_t v) { return ATOMIC_AAF(ref_ + idx(x), v); }
+
+  ObSubQueue *get_subq_from_pool() {
+    ObSubQueue *p = NULL;
+    for (uint64_t i = 0; i < QUEUE_POOL_SIZE; ++i) {
+      p = queue_pool_[i];
+      if (NULL != p && (ObSubQueue *)LOCK != p) {
+        queue_pool_[i] = NULL;
+        break;
+      }
+    }
+    return p;
+  }
+
+  uint64_t get_subq_size(uint64_t x) const {
+    uint64_t ret = 0;
+    if (NULL != array_) {
+      ObSubQueue *subq = array_[idx(x)];
+      if (NULL != subq && (ObSubQueue *)LOCK != subq) {
+        ret = subq->get_next_idx();
+      }
+    }
+    return ret;
+  }
+
+ private:
+  uint64_t pop_;
+  uint64_t push_;
+  uint64_t capacity_;
+  uint64_t subcapacity_;
+  const char *mem_label_;
+  uint64_t tenant_id_;
+  int64_t *ref_;
+  ObSubQueue *queue_pool_[QUEUE_POOL_SIZE];
+  ObSubQueue **array_;
+  ObConcurrentFIFOAllocator *allocator_;  
+};
+} // end namespace common
+} // end namespace oceanbase
+
+#endif /* OCEANBASE_MYSQL_OB_RA_QUEUE_H_ */

--- a/unittest/observer/CMakeLists.txt
+++ b/unittest/observer/CMakeLists.txt
@@ -2,9 +2,12 @@
 storage_unittest(test_hfilter_parser table/test_hfilter_parser.cpp)
 storage_unittest(test_query_response_time mysql/test_query_response_time.cpp)
 storage_unittest(test_create_executor table/test_create_executor.cpp)
-storage_unittest(test_table_aggregation table/test_table_aggregation.cpp)
 storage_unittest(test_table_sess_pool table/test_table_sess_pool.cpp)
 storage_unittest(test_ingress_bw_alloc_manager net/test_ingress_bw_alloc_manager.cpp)
+# add(fhkong): test for ObRaQueue
+storage_unittest(test_ob_ra_queue test_ob_ra_queue.cpp) 
+storage_unittest(test_ob_tl_queue test_ob_tl_queue.cpp) 
+storage_unittest(test_ob_mysql_request_manager test_ob_mysql_request_manager.cpp) 
 ob_unittest(test_uniq_task_queue)
 
 add_subdirectory(rpc EXCLUDE_FROM_ALL)

--- a/unittest/observer/test_ob_mysql_request_manager.cpp
+++ b/unittest/observer/test_ob_mysql_request_manager.cpp
@@ -36,14 +36,18 @@ public:
 
 };
 
-TEST_F(TestObMysqlRequestManager, init_test)
+TEST_F(TestObMysqlRequestManager, InitTest)
 {
   ObMySQLRequestManager request_manager;
-  int ret = request_manager.init(2 * 1024 * 1024, 1000);
+  uint64_t tenant_id = OB_INVALID_TENANT_ID;
+  uint64_t queue_size = 10;
+  uint64_t subqueue_size = 100;
+  int ret = request_manager.init(tenant_id, queue_size, subqueue_size);
   OB_ASSERT(OB_SUCC(ret));
 }
 
-TEST_F(TestObMysqlRequestManager, basic_test)
+/*
+TEST_F(TestObMysqlRequestManager, DISABLED_BasicTest)
 {
   ObMySQLRequestManager request_manager;
   int ret = request_manager.init(2*1024*1024, 100000);
@@ -124,15 +128,14 @@ static void do_push(ObMySQLRequestManager *manager)
   session.init(0, 0, 0, &allocator);
   session.set_user(uname, OB_DEFAULT_HOST_NAME, 10);
 
-  /*
-  ObMySQLRawPacket packet;
-  char sql[100];
-  memset(sql, 'a', 100);
-  packet.set_cmd(oceanbase::obmysql::COM_QUERY);
-  packet.set_content(sql, 100);
-  //packet.set_header(100,1);
-  //packet.set_receive_ts(10000);
-  */
+  // ObMySQLRawPacket packet;
+  // char sql[100];
+  // memset(sql, 'a', 100);
+  // packet.set_cmd(oceanbase::obmysql::COM_QUERY);
+  // packet.set_content(sql, 100);
+  // //packet.set_header(100,1);
+  // //packet.set_receive_ts(10000);
+
   ObMySQLResultSet result;
   result.set_errcode(0);
   result.set_affected_rows(100);
@@ -180,6 +183,7 @@ TEST_F(TestObMysqlRequestManager, multithread_test)
     threads[i].join();
   }
 }
+*/
 
 } // namespace test
 } // namespace oceanbase

--- a/unittest/observer/test_ob_ra_queue.cpp
+++ b/unittest/observer/test_ob_ra_queue.cpp
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2021 OceanBase
+ * OceanBase CE is licensed under Mulan PubL v2.
+ * You can use this software according to the terms and conditions of the Mulan PubL v2.
+ * You may obtain a copy of Mulan PubL v2 at:
+ *          http://license.coscl.org.cn/MulanPubL-2.0
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PubL v2 for more details.
+ */
+
+#define USING_LOG_PREFIX SERVER
+
+#include <gtest/gtest.h>
+#include <thread>
+#include "share/ob_define.h"
+#include "observer/mysql/ob_ra_queue.h"
+
+using namespace oceanbase::common;
+
+namespace oceanbase {
+namespace test {
+
+struct DummyAuditRecod {
+  uint64_t val;
+};
+
+TEST(TestObRaQueue, DummyTest) {
+  EXPECT_EQ(1 + 1, 2);
+}
+
+TEST(TestObRaQueue, InitTest) {
+  ObRaQueue queue;
+  int ret = queue.init(ObModIds::OB_MYSQL_REQUEST_RECORD, 100);
+  EXPECT_EQ(OB_SUCCESS, ret);
+}
+
+TEST(TestObRaQueue, BasicTest) {
+  ObRaQueue queue;
+  const uint64_t queue_size = 1024;
+  int ret = queue.init(ObModIds::OB_MYSQL_REQUEST_RECORD, queue_size);
+  EXPECT_EQ(OB_SUCCESS, ret);
+
+  std::vector<DummyAuditRecod*> audits;
+  for (uint64_t i = 0; i < queue_size; ++i) {
+    auto *audit = static_cast<DummyAuditRecod*>(malloc(sizeof(DummyAuditRecod)));
+    audit->val = i;
+    audits.push_back(audit);
+  }
+  int64_t seq = 0;
+  int64_t global_id = 0;
+  for (auto *audit : audits) {
+    ret = queue.push(audit, seq);
+    EXPECT_EQ(OB_SUCCESS, ret);
+    EXPECT_EQ(global_id++, seq);
+  }
+
+  // check get_pop_idx and get_push_idx
+  EXPECT_EQ(0, queue.get_pop_idx());
+  EXPECT_EQ(queue_size, queue.get_push_idx());
+
+  // check size valid
+  EXPECT_EQ(queue.get_size(), queue_size);
+
+  ObRaQueue::Ref ref; 
+  // check get function
+  for (uint64_t req_id = 0; req_id < queue_size; ++req_id) {
+    auto *audit = queue.get(req_id, &ref);
+    EXPECT_NE(audit, nullptr);
+    EXPECT_EQ(static_cast<DummyAuditRecod*>(audit)->val, req_id);
+    EXPECT_EQ(ref.idx_, req_id);
+    queue.revert(&ref);
+  }
+
+  // check pop function
+  for (uint64_t i = 0; i < queue_size; ++i) {
+    auto *audit = queue.pop();
+    EXPECT_NE(audit, nullptr);
+    free(audit);
+  }
+
+  EXPECT_EQ(0, queue.get_size());
+}
+
+TEST(TestObRaQueue, PushTest) {
+  ObRaQueue queue;
+  const uint64_t queue_size = 1024;
+  int ret = queue.init(ObModIds::OB_MYSQL_REQUEST_RECORD, queue_size);
+  EXPECT_EQ(OB_SUCCESS, ret);
+
+  std::vector<DummyAuditRecod*> audits;
+  for (uint64_t i = 0; i < queue_size * 2 ; ++i) {
+    auto *audit = static_cast<DummyAuditRecod*>(malloc(sizeof(DummyAuditRecod)));
+    audit->val = i;
+    audits.push_back(audit);
+  }
+  int64_t seq = 0;
+  int64_t global_id = 0;
+  for (uint64_t i = 0;  i < queue_size; ++i) {
+    ret = queue.push(audits[i], seq);
+    EXPECT_EQ(OB_SUCCESS, ret);
+    EXPECT_EQ(global_id++, seq);
+  }
+
+  // check get_pop_idx and get_push_idx
+  EXPECT_EQ(0, queue.get_pop_idx());
+  EXPECT_EQ(queue_size, queue.get_push_idx());
+  // check size valid
+  EXPECT_EQ(queue.get_size(), queue_size);
+
+  // push again
+  for (uint64_t i = 0; i < queue_size; ++i) {
+    ret = queue.push(audits[i + queue_size], seq);
+    EXPECT_EQ(OB_ENTRY_NOT_EXIST, ret);
+  }
+  EXPECT_EQ(queue.get_size(), queue_size);
+
+  for (uint64_t i = 0; i < queue_size; ++i) {
+    auto *audit = queue.pop();
+    EXPECT_NE(audit, nullptr);
+    free(audit);
+  }
+  EXPECT_EQ(queue.get_size(), 0);
+
+  // now we can push again 
+  for (uint64_t i = 0; i < queue_size; ++i) {
+    ret = queue.push(audits[i + queue_size], seq);
+    EXPECT_EQ(OB_SUCCESS, ret);
+  }
+  EXPECT_EQ(queue_size, queue.get_pop_idx());
+  EXPECT_EQ(2 * queue_size, queue.get_push_idx());
+  EXPECT_EQ(queue.get_size(), queue_size);
+  
+  // check get function
+  ObRaQueue::Ref ref; 
+  for (uint64_t req_id = queue_size; req_id < 2 * queue_size; ++req_id) {
+    auto *audit = queue.get(req_id, &ref);
+    EXPECT_NE(audit, nullptr);
+    EXPECT_EQ(static_cast<DummyAuditRecod*>(audit)->val, req_id);
+    EXPECT_EQ(ref.idx_, global_id++);
+    queue.revert(&ref);
+  }
+
+  // check pop function
+  for (uint64_t i = 0; i < queue_size; ++i) {
+    auto *audit = queue.pop();
+    EXPECT_NE(audit, nullptr);
+    free(audit);
+  }
+  EXPECT_EQ(0, queue.get_size());
+}
+
+TEST(TestObRaQueue, ConcurrentPushTest) {
+  ObRaQueue queue;
+  const uint64_t queue_size = 1024 * 1024 * 80;
+  const uint64_t thread_num = 5;
+  int ret = queue.init(ObModIds::OB_MYSQL_REQUEST_RECORD, queue_size);
+  EXPECT_EQ(OB_SUCCESS, ret);
+
+  std::vector<DummyAuditRecod*> audits;
+  for (uint64_t i = 0; i < queue_size ; ++i) {
+    auto *audit = static_cast<DummyAuditRecod*>(malloc(sizeof(DummyAuditRecod)));
+    audit->val = i;
+    audits.push_back(audit);
+  }
+
+  auto PushHelpr = [&queue, &audits](uint64_t thread_itr) {
+    int ret = OB_SUCCESS;
+    int64_t seq = 0;
+    for (uint64_t i = 0; i < audits.size(); ++i) {
+      if (i % thread_num == thread_itr) {
+        ret = queue.push(audits[i], seq);
+        EXPECT_EQ(ret, OB_SUCCESS);
+      }
+    }
+  };
+
+  std::vector<std::thread> thread_pool;
+  for (uint64_t thread_itr = 0; thread_itr < thread_num; ++thread_itr) {
+    thread_pool.emplace_back(PushHelpr, thread_itr);
+  }
+  for (auto &t : thread_pool) {
+    t.join();
+  }
+
+  // check push success
+  EXPECT_EQ(0, queue.get_pop_idx());
+  EXPECT_EQ(queue_size, queue.get_push_idx());
+  EXPECT_EQ(queue.get_size(), queue_size);
+
+  // get
+  ObRaQueue::Ref ref; 
+  for (uint64_t req_id = 0; req_id < queue_size; ++req_id) {
+    auto *audit = queue.get(req_id, &ref);
+    EXPECT_NE(audit, nullptr);
+    queue.revert(&ref);
+  }
+
+  // check pop function
+  for (uint64_t i = 0; i < queue_size; ++i) {
+    auto *audit = queue.pop();
+    EXPECT_NE(audit, nullptr);
+    free(audit);
+  }
+  EXPECT_EQ(0, queue.get_size());
+}
+
+
+} // namespace test
+} // namespace oceanbase
+
+int main(int argc, char *argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/unittest/observer/test_ob_tl_queue.cpp
+++ b/unittest/observer/test_ob_tl_queue.cpp
@@ -1,0 +1,401 @@
+/**
+ * Copyright (c) 2021 OceanBase
+ * OceanBase CE is licensed under Mulan PubL v2.
+ * You can use this software according to the terms and conditions of the Mulan PubL v2.
+ * You may obtain a copy of Mulan PubL v2 at:
+ *          http://license.coscl.org.cn/MulanPubL-2.0
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PubL v2 for more details.
+ */
+
+#define USING_LOG_PREFIX SERVER
+
+#include <gtest/gtest.h>
+#include <thread>
+#include "share/ob_define.h"
+#include "observer/mysql/ob_tl_queue.h"
+
+using namespace oceanbase::common;
+
+namespace oceanbase {
+namespace test {
+
+struct DummyAuditRecod {
+  uint64_t val;
+};
+
+static const int64_t TOTAL_SIZE = 1024l * 1024l * 1024l * 8l;
+static const int64_t MY_PAGE_SIZE = 64 * 1024;
+
+TEST(TestObTLQueue, DummyTest) {
+  EXPECT_EQ(1 + 1, 2);
+}
+
+TEST(TestObTLQueue, InitTest) {
+  ObTLQueue queue;
+  ObConcurrentFIFOAllocator allocator;
+  ASSERT_EQ(OB_SUCCESS, allocator.init(TOTAL_SIZE, TOTAL_SIZE, MY_PAGE_SIZE));
+  const uint64_t capacity = 100;
+  const uint64_t subcapacity = 100;
+  int ret = queue.init(ObModIds::OB_MYSQL_REQUEST_RECORD, capacity, subcapacity, &allocator);
+  EXPECT_EQ(OB_SUCCESS, ret);
+}
+
+TEST(TestObTLQueue, SizeTest1) {
+  ObTLQueue queue;
+  const uint64_t capacity = 1;
+  const uint64_t subcapacity = 10;
+  const uint64_t queue_size = capacity * subcapacity;
+
+  ObConcurrentFIFOAllocator allocator;
+  ASSERT_EQ(OB_SUCCESS, allocator.init(TOTAL_SIZE, TOTAL_SIZE, MY_PAGE_SIZE));
+
+  int ret = queue.init(ObModIds::OB_MYSQL_REQUEST_RECORD, capacity, subcapacity, &allocator);
+  EXPECT_EQ(OB_SUCCESS, ret);
+
+  EXPECT_EQ(0, queue.get_size());
+  std::vector<DummyAuditRecod*> audits;
+  for (uint64_t i = 0; i < queue_size; ++i) {
+    auto *audit = static_cast<DummyAuditRecod*>(allocator.alloc(sizeof(DummyAuditRecod)));
+    audit->val = i;
+    audits.push_back(audit);
+  }
+
+  uint64_t idx = 0;
+  int64_t seq = 0;
+  ret = queue.push_with_retry(audits[idx++], seq);
+  EXPECT_EQ(OB_SUCCESS, ret);
+
+  EXPECT_EQ(1, queue.get_size());
+  ret = queue.pop_batch();
+  EXPECT_EQ(OB_SUCCESS, ret);
+  EXPECT_EQ(0, queue.get_size());
+
+  while (idx < queue_size)  {
+    ret = queue.push_with_retry(audits[idx++], seq);
+    EXPECT_EQ(OB_SUCCESS, ret);
+  }
+
+  EXPECT_EQ(queue_size - 1, queue.get_size());
+  ret = queue.pop_batch();
+  EXPECT_EQ(OB_SUCCESS, ret);
+  EXPECT_EQ(0, queue.get_size());
+}
+
+TEST(TestObTLQueue, SizeTest2) {
+  ObTLQueue queue;
+  const uint64_t capacity = 2;
+  const uint64_t subcapacity = 10;
+  const uint64_t queue_size = capacity * subcapacity;
+  const uint64_t item_size = queue_size + 5;
+
+  ObConcurrentFIFOAllocator allocator;
+  ASSERT_EQ(OB_SUCCESS, allocator.init(TOTAL_SIZE, TOTAL_SIZE, MY_PAGE_SIZE));
+
+  int ret = queue.init(ObModIds::OB_MYSQL_REQUEST_RECORD, capacity, subcapacity, &allocator);
+  EXPECT_EQ(OB_SUCCESS, ret);
+
+  EXPECT_EQ(0, queue.get_size());
+  std::vector<DummyAuditRecod*> audits;
+  for (uint64_t i = 0; i < item_size; ++i) {
+    auto *audit = static_cast<DummyAuditRecod*>(allocator.alloc(sizeof(DummyAuditRecod)));
+    audit->val = i;
+    audits.push_back(audit);
+  }
+
+  uint64_t idx = 0;
+  int64_t seq = 0;
+  for (uint64_t i = 0; i < queue_size; ++i) {
+    ret = queue.push_with_retry(audits[i], seq);
+    EXPECT_EQ(OB_SUCCESS, ret);
+    EXPECT_EQ(i, seq);
+  }
+  EXPECT_EQ(queue_size, queue.get_size());
+
+  // pop one batch
+  ret = queue.pop_batch();
+  EXPECT_EQ(OB_SUCCESS, ret);
+  EXPECT_EQ(queue_size - subcapacity, queue.get_size());
+
+  for (uint64_t i = queue_size; i < item_size; ++i) {
+    ret = queue.push_with_retry(audits[i], seq);
+    EXPECT_EQ(OB_SUCCESS, ret);
+    EXPECT_EQ(i, seq);
+  }
+  EXPECT_EQ(item_size - subcapacity, queue.get_size());
+
+  // pop and free
+  while (OB_SUCC(queue.pop_batch())) {
+    ;
+  }
+  EXPECT_EQ(0, queue.get_size());
+}
+TEST(TestObTLQueue, SizeTest3) {
+  ObTLQueue queue;
+  const uint64_t capacity = 2;
+  const uint64_t subcapacity = 10;
+  const uint64_t queue_size = capacity * subcapacity;
+  const uint64_t item_size = queue_size - 1;
+
+  ObConcurrentFIFOAllocator allocator;
+  ASSERT_EQ(OB_SUCCESS, allocator.init(TOTAL_SIZE, TOTAL_SIZE, MY_PAGE_SIZE));
+  int ret = queue.init(ObModIds::OB_MYSQL_REQUEST_RECORD, capacity, subcapacity, &allocator);
+  EXPECT_EQ(OB_SUCCESS, ret);
+
+  EXPECT_EQ(0, queue.get_size());
+  std::vector<DummyAuditRecod*> audits;
+  for (uint64_t i = 0; i < item_size; ++i) {
+    auto *audit = static_cast<DummyAuditRecod*>(allocator.alloc(sizeof(DummyAuditRecod)));
+    audit->val = i;
+    audits.push_back(audit);
+  }
+
+  uint64_t idx = 0;
+  int64_t seq = 0;
+  ret = queue.pop_batch();
+  EXPECT_EQ(0, queue.get_size());
+  EXPECT_EQ(OB_ENTRY_NOT_EXIST, ret);
+
+  while (idx < item_size)  {
+    ret = queue.push_with_retry(audits[idx++], seq);
+    EXPECT_EQ(OB_SUCCESS, ret);
+  }
+
+  EXPECT_EQ(item_size, queue.get_size());
+  ret = queue.pop_batch();
+  EXPECT_EQ(OB_SUCCESS, ret);
+  EXPECT_EQ(subcapacity - 1, queue.get_size());
+
+  ret = queue.pop_batch();
+  EXPECT_EQ(OB_SUCCESS, ret);
+  EXPECT_EQ(0, queue.get_size());
+}
+
+TEST(TestObTLQueue, BasicTest) {
+  ObTLQueue queue;
+  const uint64_t capacity = 6;
+  const uint64_t subcapacity = 10;
+  const uint64_t queue_size = capacity * subcapacity;
+
+  ObConcurrentFIFOAllocator allocator;
+  ASSERT_EQ(OB_SUCCESS, allocator.init(TOTAL_SIZE, TOTAL_SIZE, MY_PAGE_SIZE));
+  int ret = queue.init(ObModIds::OB_MYSQL_REQUEST_RECORD, capacity, subcapacity, &allocator);
+  EXPECT_EQ(OB_SUCCESS, ret);
+  std::vector<DummyAuditRecod*> audits;
+  for (uint64_t i = 0; i < queue_size; ++i) {
+    auto *audit = static_cast<DummyAuditRecod*>(allocator.alloc(sizeof(DummyAuditRecod)));
+    audit->val = i;
+    audits.push_back(audit);
+  }
+  int64_t seq = 0;
+  int64_t global_id = 0;
+  for (auto *audit : audits) {
+    ret = queue.push_with_retry(audit, seq);
+    EXPECT_EQ(OB_SUCCESS, ret);
+    EXPECT_EQ(global_id++, seq);
+  }
+
+  // check get_pop_idx and get_push_idx
+  EXPECT_EQ(0, queue.get_head_idx());
+  EXPECT_EQ(queue_size, queue.get_tail_idx());
+
+  // check size valid
+  EXPECT_EQ(queue.get_size(), queue_size);
+
+  ObRaQueue::Ref ref; 
+  // check get function
+  for (uint64_t req_id = 0; req_id < queue_size; ++req_id) {
+    auto *audit = queue.get(req_id, &ref);
+    EXPECT_NE(audit, nullptr);
+    EXPECT_EQ(static_cast<DummyAuditRecod*>(audit)->val, req_id);
+    EXPECT_EQ(ref.idx_, req_id);
+    queue.revert(&ref);
+  }
+
+  // check pop function
+  for (uint64_t i = 0; i < capacity; ++i) {
+    ret = queue.pop_batch();
+    EXPECT_EQ(ret, OB_SUCCESS);
+  }
+
+  EXPECT_EQ(0, queue.get_size());
+}
+
+TEST(TestObTLQueue, PushTest1) {
+  ObTLQueue queue;
+  const uint64_t capacity = 10;
+  const uint64_t subcapacity = 100;
+  const uint64_t queue_size = capacity * subcapacity;
+  const uint64_t item_size = queue_size + 1;
+
+  ObConcurrentFIFOAllocator allocator;
+  ASSERT_EQ(OB_SUCCESS, allocator.init(TOTAL_SIZE, TOTAL_SIZE, MY_PAGE_SIZE));
+  int ret = queue.init(ObModIds::OB_MYSQL_REQUEST_RECORD, capacity, subcapacity, &allocator);
+  EXPECT_EQ(OB_SUCCESS, ret);
+
+  std::vector<DummyAuditRecod*> audits;
+  for (uint64_t i = 0; i < item_size ; ++i) {
+    auto *audit = static_cast<DummyAuditRecod*>(allocator.alloc(sizeof(DummyAuditRecod)));
+    audit->val = i;
+    audits.push_back(audit);
+  }
+  int64_t seq = 0;
+  int64_t global_id = 0;
+  for (uint64_t i = 0;  i < queue_size; ++i) {
+    ret = queue.push_with_retry(audits[i], seq);
+    EXPECT_EQ(OB_SUCCESS, ret);
+    EXPECT_EQ(global_id++, seq);
+  }
+
+  // check get_pop_idx and get_push_idx
+  EXPECT_EQ(0, queue.get_head_idx());
+  EXPECT_EQ(queue_size, queue.get_tail_idx());
+  EXPECT_EQ(queue_size, queue.get_size());
+
+  // push again
+  for (uint64_t i = queue_size; i < item_size; ++i) {
+    ret = queue.push_with_retry(audits[i], seq);
+    EXPECT_EQ(OB_SIZE_OVERFLOW, ret);
+  }
+  EXPECT_EQ(queue.get_size(), queue_size);
+
+  ret = queue.pop_batch();
+  EXPECT_EQ(OB_SUCCESS, ret);
+  EXPECT_EQ(1 * subcapacity, queue.get_head_idx());
+  EXPECT_EQ(queue_size, queue.get_tail_idx());
+  EXPECT_EQ(queue.get_size(), queue_size - subcapacity);
+
+  // now we can push again 
+  for (uint64_t i = queue_size; i < item_size; ++i) {
+    ret = queue.push_with_retry(audits[i], seq);
+    EXPECT_EQ(OB_SUCCESS, ret);
+  }
+  EXPECT_EQ(1 * subcapacity, queue.get_head_idx());
+  EXPECT_EQ(queue_size + 1, queue.get_tail_idx());
+  EXPECT_EQ(queue.get_size(), item_size - subcapacity);
+  
+  // pop and free
+  while (OB_SUCC(queue.pop_batch())) {
+    ;
+  }
+  EXPECT_EQ(0, queue.get_size());
+}
+TEST(TestObTLQueue, PushTest2) {
+  ObTLQueue queue;
+  const uint64_t capacity = 100;
+  const uint64_t subcapacity = 1000;
+  const uint64_t queue_size = capacity * subcapacity;
+
+  ObConcurrentFIFOAllocator allocator;
+  ASSERT_EQ(OB_SUCCESS, allocator.init(TOTAL_SIZE, TOTAL_SIZE, MY_PAGE_SIZE));
+  int ret = queue.init(ObModIds::OB_MYSQL_REQUEST_RECORD, capacity, subcapacity, &allocator);
+  EXPECT_EQ(OB_SUCCESS, ret);
+
+  std::vector<DummyAuditRecod*> audits;
+  for (uint64_t i = 0; i < queue_size * 2 ; ++i) {
+    auto *audit = static_cast<DummyAuditRecod*>(allocator.alloc(sizeof(DummyAuditRecod)));
+    audit->val = i;
+    audits.push_back(audit);
+  }
+  int64_t seq = 0;
+  int64_t global_id = 0;
+  for (uint64_t i = 0;  i < queue_size; ++i) {
+    ret = queue.push_with_retry(audits[i], seq);
+    EXPECT_EQ(OB_SUCCESS, ret);
+    EXPECT_EQ(global_id++, seq);
+  }
+
+  // check get_pop_idx and get_push_idx
+  EXPECT_EQ(0, queue.get_head_idx());
+  EXPECT_EQ(queue_size, queue.get_tail_idx());
+  EXPECT_EQ(queue.get_size(), queue_size);
+
+  // push again
+  for (uint64_t i = 0; i < queue_size; ++i) {
+    ret = queue.push_with_retry(audits[i + queue_size], seq);
+    EXPECT_EQ(OB_SIZE_OVERFLOW, ret);
+  }
+  EXPECT_EQ(queue.get_size(), queue_size);
+
+  while (OB_SUCC(queue.pop_batch())) ;
+  EXPECT_EQ(queue.get_size(), 0);
+
+  // now we can push again 
+  for (uint64_t i = 0; i < queue_size; ++i) {
+    ret = queue.push_with_retry(audits[i + queue_size], seq);
+    EXPECT_EQ(OB_SUCCESS, ret);
+  }
+  EXPECT_EQ(queue_size, queue.get_head_idx());
+  EXPECT_EQ(2 * queue_size, queue.get_tail_idx());
+  EXPECT_EQ(queue.get_size(), queue_size);
+  
+  while (OB_SUCC(queue.pop_batch())) ;
+  EXPECT_EQ(0, queue.get_size());
+}
+
+TEST(TestObTLQueue, ConcurrentPushTest) {
+  ObTLQueue queue;
+  const uint64_t capacity = 1024; 
+  const uint64_t subcapacity = 50000; // 5w
+  const uint64_t queue_size = capacity * subcapacity;  // 5000w
+  const uint64_t thread_num = 5;
+
+  ObConcurrentFIFOAllocator allocator;
+  ASSERT_EQ(OB_SUCCESS, allocator.init(TOTAL_SIZE, TOTAL_SIZE, MY_PAGE_SIZE));
+  int ret = queue.init(ObModIds::OB_MYSQL_REQUEST_RECORD, capacity, subcapacity, &allocator);
+  EXPECT_EQ(OB_SUCCESS, ret);
+
+  std::vector<DummyAuditRecod*> audits;
+  for (uint64_t i = 0; i < queue_size ; ++i) {
+    auto *audit = static_cast<DummyAuditRecod*>(allocator.alloc(sizeof(DummyAuditRecod)));
+    audit->val = i;
+    audits.push_back(audit);
+  }
+
+  auto PushHelpr = [&queue, &audits](uint64_t thread_itr) {
+    int ret = OB_SUCCESS;
+    int64_t seq = 0;
+    for (uint64_t i = 0; i < audits.size(); ++i) {
+      if (i % thread_num == thread_itr) {
+        ret = queue.push_with_retry(audits[i], seq);
+        EXPECT_EQ(ret, OB_SUCCESS);
+      }
+    }
+  };
+
+  std::vector<std::thread> thread_pool;
+  for (uint64_t thread_itr = 0; thread_itr < thread_num; ++thread_itr) {
+    thread_pool.emplace_back(PushHelpr, thread_itr);
+  }
+  for (auto &t : thread_pool) {
+    t.join();
+  }
+
+  // check push success
+  EXPECT_EQ(queue.get_size(), queue_size);
+
+  // get
+  ObRaQueue::Ref ref; 
+  for (uint64_t req_id = 0; req_id < queue_size; ++req_id) {
+    auto *audit = queue.get(req_id, &ref);
+    EXPECT_NE(audit, nullptr);
+    queue.revert(&ref);
+  }
+
+  // check pop function
+  while (OB_SUCC(queue.pop_batch())) {
+    ;
+  }
+  EXPECT_EQ(0, queue.get_size());
+}
+
+} // namespace test
+} // namespace oceanbase
+
+int main(int argc, char *argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase**! 
Please read the [How to Contribute](https://github.com/oceanbase/oceanbase/wiki/how_to_contribute) document **BEFORE** filling this PR.

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description
ObMySQLRequestManager中使用 一个无锁的 ObRaQueue 记录每一个 audit 记录的指针。ObRaQueue 是无锁实现，但内存是静态申请的，导致在小租户下内存占用较大 (80M) 。目前仅在meta租户和mini mode下使用较小的queue size初始化以减少内存占用，但不能处理租户内存扩缩容场景，希望将此queue做为动态大小。

### Solution Description
设计目标：
1. 向上提供随机读取的接口；
2. 支持内存动态扩缩容；
3. 无锁实现高并发线程安全；

具体细节：
![image](https://github.com/oceanbase/oceanbase/assets/45626125/e1023d42-76e1-4356-a809-f1d986bdc60d)
使用一个两层队列的结构，通过构造多个小的静态队列来组成一个大的动态队列。
1. 节点内存：一级队列存放二级队列的指针和该二级队列上的引用计数，占用16B；二级队列存在每个Audit记录的指针，占用8B；
2. 扩缩容：每次操作的粒度为一个小队列的大小（Evict Batch）。Batch设置的越小，队列的内存可控粒度越小，但malloc/free操作越频繁；

### Passed Regressions
oceanbase/unittest/observer/test_ob_ra_queue.cpp
oceanbase/unittest/observer/test_ob_tl_queue.cpp
oceanbase/unittest/observer/test_ob_mysql_request_manager.cpp

### Upgrade Compatibility

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

### Other Information

<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
