### PR TITLE
bug fix: Queries containing window functions cannot push down the GROUP BY operation

### DIFF
--- a/src/sql/rewrite/ob_transform_groupby_pushdown.cpp
+++ b/src/sql/rewrite/ob_transform_groupby_pushdown.cpp
@@ -176,8 +176,7 @@ int ObTransformGroupByPushdown::check_groupby_push_down_validity(ObSelectStmt *s
     is_valid = false;
     OPT_TRACE("do not rewrite inner table stmt with cost-based rule");
     // do not rewrite inner table stmt with cost-based rule
-  } else if (stmt->has_window_function() ||
-             stmt->has_rollup() ||
+  } else if (stmt->has_rollup() ||
              stmt->get_semi_infos().count() > 0 ||
              stmt->get_subquery_exprs().count() > 0 ||
              stmt->get_aggr_item_size() <= 0 ||


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase**! 
Please read the [How to Contribute](https://github.com/oceanbase/oceanbase/wiki/how_to_contribute) document **BEFORE** filling this PR.

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description
close #2032 

<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->

### Solution Description
Lift the restrictions on winfun regarding pushing down group by
<!-- Please clearly and consice descipt the solution. -->
