### PR TITLE
HashJoin MCV Optimization

### DIFF
--- a/src/sql/code_generator/ob_static_engine_cg.cpp
+++ b/src/sql/code_generator/ob_static_engine_cg.cpp
@@ -5889,6 +5889,9 @@ int ObStaticEngineCG::generate_spec(ObLogJoin &op, ObHashJoinVecSpec &spec, cons
           }
         }
       }
+      if (OB_SUCC(ret) && OB_FAIL(hj_spec.right_popular_values_.assign(op.get_popular_values()))) {
+        LOG_WARN("failed to init popular_values");
+      }
     }
   }
 

--- a/src/sql/engine/join/hash_join/join_hash_table.cpp
+++ b/src/sql/engine/join/hash_join/join_hash_table.cpp
@@ -48,7 +48,7 @@ int JoinHashTable::init(JoinTableCtx &hjt_ctx, ObIAllocator &allocator)
   LOG_DEBUG("init join hash table", K(use_normalized), K(hjt_ctx.is_shared_),
             K(hjt_ctx.build_keys_->count()));
   if (hjt_ctx.is_shared_) {
-    if (use_normalized ) {
+    if (use_normalized) {
       if (1 == hjt_ctx.build_keys_->count()) {
         //hash_table_ = OB_NEWx(NormalizedSharedInt64Table, (&allocator));
         hash_table_ = OB_NEWx(GenericSharedHashTable, (&allocator));
@@ -60,7 +60,7 @@ int JoinHashTable::init(JoinTableCtx &hjt_ctx, ObIAllocator &allocator)
       hash_table_ = OB_NEWx(GenericSharedHashTable, (&allocator));
     }
   } else {
-    if (use_normalized ) {
+    if (use_normalized) {
       if (1 == hjt_ctx.build_keys_->count()) {
         hash_table_ = OB_NEWx(NormalizedInt64Table, (&allocator));
       } else if (2 == hjt_ctx.build_keys_->count()) {
@@ -79,12 +79,68 @@ int JoinHashTable::init(JoinTableCtx &hjt_ctx, ObIAllocator &allocator)
   return ret;
 }
 
+int JoinHashTable::init_mcv(JoinTableCtx &hjt_ctx, ObIAllocator &allocator, 
+                            uint64_t *mcv_hash_vals, int64_t &n_mcv) 
+{
+  int ret = OB_SUCCESS;
+  bool use_normalized = use_normalized_ht(hjt_ctx);
+  LOG_DEBUG("init mcv join hash table", K(hjt_ctx.is_shared_),
+            K(hjt_ctx.build_keys_->count()));
+  if (hjt_ctx.is_shared_) {
+    mcv_hash_table_ = OB_NEWx(GenericSharedMcvHashTable, (&allocator));
+  } else {
+    if (use_normalized) {
+      if (1 == hjt_ctx.build_keys_->count()) {
+        mcv_hash_table_ = OB_NEWx(NormalizedInt64McvTable, (&allocator));
+      } else if (2 == hjt_ctx.build_keys_->count()) {
+        mcv_hash_table_ = OB_NEWx(NormalizedInt128McvTable, (&allocator));
+      }
+    } else {
+      mcv_hash_table_ = OB_NEWx(GenericMcvTable, (&allocator));
+    }
+  }
+
+  if (NULL == mcv_hash_table_) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+    LOG_WARN("fail to new hash table", K(ret));
+  } else if (OB_FAIL(ret = mcv_hash_table_->init(allocator, hjt_ctx.max_batch_size_))) {
+    LOG_WARN("alloc bucket array failed", K(ret));
+  } else {
+    static const int64_t RATIO_OF_BUCKETS = 2;
+    int64_t n_bucket = next_pow2(n_mcv * RATIO_OF_BUCKETS);
+    if (OB_FAIL(ret = mcv_hash_table_->build_prepare(n_mcv, n_bucket))) {
+      LOG_WARN("mcv_hash_table build prepare failed ", K(n_mcv), K(n_bucket));
+    } else {
+      int64_t used_buckets = 0;
+      int64_t collisions = 0;
+      if (OB_FAIL(ret = mcv_hash_table_->init_mcv_bucket_hash(hjt_ctx, mcv_hash_vals, n_mcv, 
+                                                                used_buckets, collisions))) {
+        LOG_WARN("mcv_hash_table init hash_val failed ", K(ret));
+      }
+      mcv_hash_table_->set_diag_info(used_buckets, collisions);
+    }
+  }
+  return ret;
+}
+
+int JoinHashTable::get_mcv_hash_exist(JoinTableCtx &hjt_ctx, uint64_t hash_val, bool &exist)
+{
+  return mcv_hash_table_->get_hash_exist(hjt_ctx, hash_val, exist);
+}
+
+int JoinHashTable::get_mcv_hash_exist_batch(JoinTableCtx &hjt_ctx, int64_t size, uint64_t *hash_vals, 
+                                            uint16_t *selector, uint16_t selector_cnt)
+{
+  return mcv_hash_table_->get_hash_exist_batch(hjt_ctx, hash_vals, size, selector, selector_cnt);
+}
+
 int JoinHashTable::build_prepare(JoinTableCtx &ctx, int64_t row_count, int64_t bucket_count) {
   ctx.reuse();
   return hash_table_->build_prepare(row_count, bucket_count);
 }
 
-int JoinHashTable::build(JoinPartitionRowIter &iter, JoinTableCtx &ctx) {
+int JoinHashTable::build(bool is_mcv, JoinPartitionRowIter &iter, JoinTableCtx &ctx)
+{
   int ret = OB_SUCCESS;
   int64_t used_buckets = 0;
   int64_t collisions = 0;
@@ -96,13 +152,26 @@ int JoinHashTable::build(JoinPartitionRowIter &iter, JoinTableCtx &ctx) {
       if (OB_ITER_END != ret) {
         LOG_WARN("get next batch failed", K(ret));
       }
-    } else if (OB_FAIL(hash_table_->insert_batch(ctx,
+    } else if (0 == read_size) {
+      ret = OB_ITER_END;
+      break;
+    } else if (!is_mcv && OB_FAIL(hash_table_->insert_batch(ctx,
             const_cast<ObHJStoredRow **>(ctx.stored_rows_), read_size, used_buckets, collisions))) {
       LOG_WARN("fail to insert batch", K(ret));
+    } else if (is_mcv && OB_FAIL(mcv_hash_table_->insert_batch(ctx,
+            const_cast<ObHJStoredRow **>(ctx.stored_rows_), read_size, used_buckets, collisions))) {
+      LOG_WARN("fail to insert mcv batch", K(ret));
     }
     LOG_DEBUG("build hash join table", K(read_size), K(ret));
   }
-  hash_table_->set_diag_info(used_buckets, collisions);
+  if (!is_mcv) {
+    hash_table_->set_diag_info(used_buckets, collisions);
+  } else {
+    mcv_hash_table_->set_diag_info(used_buckets, collisions);
+    if (OB_FAIL(mcv_hash_table_->finish_build_mcv(ctx))) {
+      LOG_WARN("fail to finsh build mcv", K(ret));
+    }
+  }
 
   if (OB_ITER_END == ret) {
     ret = OB_SUCCESS;
@@ -115,17 +184,84 @@ int JoinHashTable::build(JoinPartitionRowIter &iter, JoinTableCtx &ctx) {
 // hash_table probe prepare
 //   * prefect bucket for probe active rows
 //   * init matched buckets array for probe active rows
-int JoinHashTable::probe_prepare(JoinTableCtx &ctx, OutputInfo &output_info) {
-  return hash_table_->probe_prepare(ctx, output_info);
+int JoinHashTable::probe_prepare(JoinTableCtx &ctx, OutputInfo &output_info)
+{
+  int ret = OB_SUCCESS;
+  if (0 < output_info.mcv_selector_cnt_
+      && OB_FAIL(mcv_hash_table_->probe_prepare(ctx, 
+                                                 output_info.mcv_selector_, 
+                                                 output_info.mcv_selector_cnt_))) {
+    LOG_WARN("fail to prepare mcv batch");
+  } else if (OB_FAIL(hash_table_->probe_prepare(ctx,
+                                                output_info.selector_,
+                                                output_info.selector_cnt_))) {
+    LOG_WARN("fail to prepare batch");
+  }
+  return ret;
 }
 
-int JoinHashTable::probe_batch(JoinTableCtx &ctx, OutputInfo &output_info) {
-  return hash_table_->probe_batch(ctx, output_info);
+int JoinHashTable::probe_batch(JoinTableCtx &ctx, OutputInfo &output_info)
+{
+  int ret = OB_SUCCESS;
+  if (0 < output_info.mcv_selector_cnt_ 
+      && OB_FAIL(mcv_hash_table_->probe_batch(
+                                    ctx, output_info, 
+                                    output_info.mcv_selector_, 
+                                    output_info.mcv_selector_cnt_, 
+                                    ctx.mcv_cur_items_, 
+                                    0))) {
+    LOG_WARN("fail to probe mcv batch");
+  } else if (OB_FAIL(hash_table_->probe_batch(
+                                    ctx, output_info, 
+                                    output_info.selector_, 
+                                    output_info.selector_cnt_, 
+                                    ctx.cur_items_, 
+                                    output_info.mcv_selector_cnt_))) {
+    LOG_WARN("fail to probe batch");
+  }
+  output_info.first_probe_ = false;
+
+  return ret;
 }
+
+int JoinHashTable::project_matched_rows(JoinTableCtx &ctx, OutputInfo &output_info)
+{
+  int ret = OB_SUCCESS;
+  if (0 < output_info.mcv_selector_cnt_ 
+      && OB_FAIL(mcv_hash_table_->project_matched_rows(
+                                    ctx,
+                                    output_info.left_result_rows_,
+                                    output_info.mcv_selector_, 
+                                    output_info.mcv_selector_cnt_))) {
+    LOG_WARN("fail to probe mcv batch");
+  } else if (OB_FAIL(hash_table_->project_matched_rows(
+                                    ctx,
+                                    output_info.left_result_rows_,
+                                    output_info.selector_, 
+                                    output_info.selector_cnt_))) {
+    LOG_WARN("fail to probe batch");
+  }
+  return ret;
+};
 
 int JoinHashTable::get_unmatched_rows(JoinTableCtx &ctx, OutputInfo &output_info)
 {
-  return hash_table_->get_unmatched_rows(ctx, output_info);
+  int ret = OB_SUCCESS;
+  output_info.selector_cnt_ = 0;
+  output_info.mcv_selector_cnt_ = 0;
+  ret = hash_table_->get_unmatched_rows(ctx,
+                                        output_info.left_result_rows_, 
+                                        ctx.cur_bkid_,
+                                        ctx.cur_tuple_,
+                                        output_info.selector_cnt_);
+  if (ctx.is_probe_skew_ && OB_ITER_END == ret && 0 == output_info.selector_cnt_) {
+    ret = mcv_hash_table_->get_unmatched_rows(ctx, 
+                                              output_info.left_result_rows_, 
+                                              ctx.mcv_cur_bkid_, 
+                                              ctx.mcv_cur_tuple_, 
+                                              output_info.mcv_selector_cnt_);
+  }
+  return ret;
 }
 
 } // end namespace sql

--- a/src/sql/engine/join/hash_join/join_hash_table.h
+++ b/src/sql/engine/join/hash_join/join_hash_table.h
@@ -22,31 +22,43 @@ namespace sql
 
 class JoinHashTable {
 public:
-  JoinHashTable() : hash_table_(NULL)
+  JoinHashTable() : hash_table_(NULL), mcv_hash_table_(NULL)
   {}
   int init(JoinTableCtx &hjt_ctx, ObIAllocator &allocator);
+  int init_mcv(JoinTableCtx &hjt_ctx, ObIAllocator &allocator, 
+                           uint64_t *mcv_hash_vals, int64_t &n_mcv);
   bool use_normalized_ht(JoinTableCtx &hjt_ctx);
   int build_prepare(JoinTableCtx &ctx, int64_t row_count, int64_t bucket_count);
-  int build(JoinPartitionRowIter &iter, JoinTableCtx &jt_ctx);
+  int build(bool is_mcv, JoinPartitionRowIter &iter, JoinTableCtx &jt_ctx);
+  int get_mcv_hash_exist(JoinTableCtx &hjt_ctx, uint64_t hash_val, bool &exist);
+  int get_mcv_hash_exist_batch(JoinTableCtx &hjt_ctx, int64_t size, uint64_t *hash_vals, 
+                               uint16_t *selector, uint16_t selector_cnt);
   int probe_prepare(JoinTableCtx &ctx, OutputInfo &output_info);
   int probe_batch(JoinTableCtx &ctx, OutputInfo &output_info);
-  int project_matched_rows(JoinTableCtx &ctx, OutputInfo &output_info) {
-    return hash_table_->project_matched_rows(ctx, output_info);
-  };
+  int project_matched_rows(JoinTableCtx &ctx, OutputInfo &output_info);
   int get_unmatched_rows(JoinTableCtx &ctx, OutputInfo &output_info);
   void reset() {
     if (NULL != hash_table_) {
       hash_table_->reset();
     }
+    if (NULL != mcv_hash_table_) {
+      mcv_hash_table_->reset();
+    }
   };
   int64_t get_mem_used() const {
-    return hash_table_->get_mem_used();
+    return hash_table_->get_mem_used() + 
+           (mcv_hash_table_ == NULL ? 0 : mcv_hash_table_->get_mem_used());
   }
   void free(ObIAllocator *allocator) {
     if (NULL != hash_table_) {
       hash_table_->free(allocator);
       allocator->free(hash_table_);
       hash_table_ = NULL;
+    }
+    if (NULL != mcv_hash_table_) {
+      mcv_hash_table_->free(allocator);
+      allocator->free(mcv_hash_table_);
+      mcv_hash_table_ = NULL;
     }
   }
   int64_t get_one_bucket_size() const { return hash_table_->get_one_bucket_size(); }
@@ -59,6 +71,7 @@ public:
 
 private:
   IHashTable *hash_table_;
+  IHashTable *mcv_hash_table_;
 };
 
 } // end namespace sql

--- a/src/sql/engine/join/hash_join/ob_hj_partition_mgr.cpp
+++ b/src/sql/engine/join/hash_join/ob_hj_partition_mgr.cpp
@@ -36,6 +36,11 @@ void ObHJPartitionMgr::reset()
     }
   }
   part_pair_list_.clear();
+
+  if (NULL != mcv_part_) {
+    free(mcv_part_);
+    mcv_part_ = NULL;
+  }
 }
 
 int ObHJPartitionMgr::next_part_pair(ObHJPartitionPair &part_pair) {
@@ -190,6 +195,21 @@ int ObHJPartitionMgr::get_or_create_part(int32_t level,
     }
   }
 
+  return ret;
+}
+
+int ObHJPartitionMgr::create_mcv_part(int32_t level,
+                                      int64_t part_shift,
+                                      int64_t partno,
+                                      ObHJPartition *&part) {
+  int ret = OB_SUCCESS;
+  void *buf = alloc_.alloc(sizeof(ObHJPartition));
+  if (NULL == buf) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+  } else {
+    part = new (buf) ObHJPartition(alloc_, tenant_id_, level, part_shift, partno);
+    mcv_part_ = part;
+  }
   return ret;
 }
 

--- a/src/sql/engine/join/hash_join/ob_hj_partition_mgr.h
+++ b/src/sql/engine/join/hash_join/ob_hj_partition_mgr.h
@@ -37,7 +37,8 @@ public:
     part_count_(0),
     tenant_id_(tenant_id),
     alloc_(alloc),
-    part_pair_list_(alloc)
+    part_pair_list_(alloc),
+    mcv_part_(NULL)
   {}
 
   virtual ~ObHJPartitionMgr();
@@ -56,6 +57,10 @@ public:
                          bool is_left,
                          ObHJPartition *&part,
                          bool only_get = false);
+  int create_mcv_part(int32_t level,
+                      int64_t part_shift,
+                      int64_t partno,
+                      ObHJPartition *&part);
 
   void free(ObHJPartition *&part) {
     if (NULL != part) {
@@ -67,6 +72,8 @@ public:
   }
 
 public:
+  static const int32_t MCV_PARTITION_LEVEL = -1;
+  static const int64_t MCV_PARTITION_NO = -1;
   int64_t total_dump_count_;
   int64_t total_dump_size_;
   int64_t part_count_;
@@ -76,6 +83,7 @@ private:
   uint64_t tenant_id_;
   common::ObIAllocator &alloc_;
   ObHJPartitionPairList part_pair_list_;
+  ObHJPartition *mcv_part_;
 };
 
 } // end namespace sql

--- a/src/sql/optimizer/ob_log_join.h
+++ b/src/sql/optimizer/ob_log_join.h
@@ -43,7 +43,8 @@ namespace sql
         connect_by_extra_exprs_(),
         enable_px_batch_rescan_(false),
         can_use_batch_nlj_(false),
-        join_path_(nullptr)
+        join_path_(nullptr),
+        popular_values_()
     { }
     virtual ~ObLogJoin() {}
 
@@ -165,7 +166,7 @@ namespace sql
     common::ObIArray<ObExecParamRawExpr *> &get_above_pushdown_left_params() { return above_pushdown_left_params_; }
     common::ObIArray<ObExecParamRawExpr *> &get_above_pushdown_right_params() { return above_pushdown_right_params_; }
     virtual int get_card_without_filter(double &card) override;
-
+    common::ObIArray<ObObj> &get_popular_values() { return popular_values_; }
   private:
     int set_use_batch(ObLogicalOperator* root);
     inline bool can_enable_gi_partition_pruning()
@@ -251,6 +252,7 @@ namespace sql
     JoinPath *join_path_;
     common::ObSEArray<ObExecParamRawExpr *, 4, common::ModulePageAllocator, true> above_pushdown_left_params_;
     common::ObSEArray<ObExecParamRawExpr *, 4, common::ModulePageAllocator, true> above_pushdown_right_params_;
+    common::ObSEArray<ObObj, 100> popular_values_;
 
     DISALLOW_COPY_AND_ASSIGN(ObLogJoin);
   };

--- a/src/sql/optimizer/ob_log_plan.h
+++ b/src/sql/optimizer/ob_log_plan.h
@@ -1704,6 +1704,9 @@ private: // member functions
   int get_popular_values_hash(common::ObIAllocator &allocator,
                               ObOptColumnStatHandle &handle,
                               common::ObIArray<ObObj> &popular_values) const;
+  int get_most_common_values(common::ObIAllocator &allocator,
+                             ObOptColumnStatHandle &handle,
+                             common::ObIArray<ObObj> &popular_values) const;
   int adjust_expr_properties_for_external_table(ObRawExpr *col_expr, ObRawExpr *&expr) const;
 
   int compute_duplicate_table_replicas(ObLogicalOperator *op);


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase**! 
Please read the [How to Contribute](https://github.com/oceanbase/oceanbase/wiki/how_to_contribute) document **BEFORE** filling this PR.

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description

close #2052 
<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->

### Solution Description

<!-- Please clearly and consice descipt the solution. -->

#### Solution:
- If the memory is not enough to accommodate the left table to build a hash table and the histogram analysis reveals the skew distribution in the right table, an optimization method is proposed. In the process of creating a hash table for the left table, a supplementary and compact "mcv hash table" (most common value) is constructed together with the main hash table. The MCV table selectively stores rows corresponding to the most common values. Subsequently, in the partition stage of the right table, first query the mcv hash table to find a potential match. If it is found, it will be output directly after completing the join to avoid writing this row to disk. 
- This strategy aims to minimize disk I/O and improve the overall hashjoin performance by giving priority to frequently occurring join keys.

#### Experiment:
Insufficient memory：
mcv percent | 0% | 25% | 50% | 75% | 100%
-- | -- | -- | -- | -- | --
origin | 8.043 | 7.854 | 7.393 | 6.941 | 6.314
mcv | 7.983 | 7.900 | 6.775 | 5.186 | 3.491
improvement | - | - | 8% | 25% | 45%

Sufficient memory：
mcv percent | 0% | 25% | 50% | 75% | 100%
-- | -- | -- | -- | -- | --
origin | 4.908 | 4.684 | 4.238 | 3.906 | 2.922
mcv | 4.873 | 4.636 | 4.306 | 3.857 | 2.946
improvement | - | - | - | - | -

The experimental results show that under the condition of insufficient memory, with the increase of the skew degree of the right table, the RT performance is obviously improved. Under the condition of sufficient memory, MCV optimization is automatically turned off, and the performance is not regressed.

### Passed Regressions

<!-- Unittest, mysql test or test it manually? -->

### Upgrade Compatibility

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

### Other Information

<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
