### PR TITLE
修复冗余谓词引起的选择率偏低问题

### DIFF
--- a/tools/deploy/mysql_test/test_suite/optimizer/r/mysql/precise_redundant_predicate.result
+++ b/tools/deploy/mysql_test/test_suite/optimizer/r/mysql/precise_redundant_predicate.result
@@ -1,0 +1,227 @@
+DROP TABLE IF EXISTS t1;
+CREATE TABLE t1 (
+c0 INT,
+c1 INT,
+c2 INT,
+c3 INT
+);
+DROP PROCEDURE IF EXISTS FillTable;
+CREATE PROCEDURE FillTable()
+BEGIN
+DECLARE i INT DEFAULT 0;
+WHILE i < 1000 DO
+INSERT INTO t1 (c0, c1, c2, c3) VALUES (MOD(i, 10), MOD(i, 10), MOD(i, 10), MOD(i, 10));
+SET i = i + 1;
+END WHILE;
+END //
+CALL FillTable();
+SET GLOBAL optimizer_dynamic_sampling = 0;
+alter system set enable_sql_extension = true;
+call dbms_stats.delete_table_stats('test', 't1');
+call dbms_stats.gather_table_stats('test', 't1', method_opt=>'FOR ALL COLUMNS SIZE 1');
+set ob_enable_show_trace=true;
+set ob_log_level='debug';
+explain select /*+ NO_REWRITE */ count(*) from t1 where (c2,2,c2)=(1,c2,3) and c2=2;
+Query Plan
+=================================================
+|ID|OPERATOR         |NAME|EST.ROWS|EST.TIME(us)|
+-------------------------------------------------
+|0 |SCALAR GROUP BY  |    |1       |42          |
+|1 |└─TABLE FULL SCAN|t1  |100     |41          |
+=================================================
+Outputs & filters:
+-------------------------------------
+  0 - output([T_FUN_COUNT_SUM(T_FUN_COUNT(*))]), filter(nil), rowset=256
+      group(nil), agg_func([T_FUN_COUNT_SUM(T_FUN_COUNT(*))])
+  1 - output([T_FUN_COUNT(*)]), filter([t1.c2 = 2], [(t1.c2) = (3)]), rowset=256
+      access([t1.c2]), partitions(p0)
+      is_index_back=false, is_global_index=false, filter_before_indexback[false,false], 
+      range_key([t1.__pk_increment]), range(MIN ; MAX)always true, 
+      pushdown_aggregation([T_FUN_COUNT(*)])
+explain select /*+ NO_REWRITE */ count(*) from t1 where c2=4 and c2=4;
+Query Plan
+=================================================
+|ID|OPERATOR         |NAME|EST.ROWS|EST.TIME(us)|
+-------------------------------------------------
+|0 |SCALAR GROUP BY  |    |1       |48          |
+|1 |└─TABLE FULL SCAN|t1  |100     |47          |
+=================================================
+Outputs & filters:
+-------------------------------------
+  0 - output([T_FUN_COUNT_SUM(T_FUN_COUNT(*))]), filter(nil), rowset=256
+      group(nil), agg_func([T_FUN_COUNT_SUM(T_FUN_COUNT(*))])
+  1 - output([T_FUN_COUNT(*)]), filter([t1.c2 = 4], [t1.c2 = 4]), rowset=256
+      access([t1.c2]), partitions(p0)
+      is_index_back=false, is_global_index=false, filter_before_indexback[false,false], 
+      range_key([t1.__pk_increment]), range(MIN ; MAX)always true, 
+      pushdown_aggregation([T_FUN_COUNT(*)])
+explain select /*+ NO_REWRITE */ count(*) from t1 where (c2,c3)=((2,3)) and (c2,c3)=(2,3);
+Query Plan
+=================================================
+|ID|OPERATOR         |NAME|EST.ROWS|EST.TIME(us)|
+-------------------------------------------------
+|0 |SCALAR GROUP BY  |    |1       |61          |
+|1 |└─TABLE FULL SCAN|t1  |11      |61          |
+=================================================
+Outputs & filters:
+-------------------------------------
+  0 - output([T_FUN_COUNT_SUM(T_FUN_COUNT(*))]), filter(nil), rowset=16
+      group(nil), agg_func([T_FUN_COUNT_SUM(T_FUN_COUNT(*))])
+  1 - output([T_FUN_COUNT(*)]), filter([(t1.c2, t1.c3) = (2, 3)], [(t1.c2, t1.c3) = (2, 3)]), rowset=16
+      access([t1.c2], [t1.c3]), partitions(p0)
+      is_index_back=false, is_global_index=false, filter_before_indexback[false,false], 
+      range_key([t1.__pk_increment]), range(MIN ; MAX)always true, 
+      pushdown_aggregation([T_FUN_COUNT(*)])
+explain select /*+ NO_REWRITE */ count(*) from t1 where (2,2) in ((c2,c2));
+Query Plan
+=================================================
+|ID|OPERATOR         |NAME|EST.ROWS|EST.TIME(us)|
+-------------------------------------------------
+|0 |SCALAR GROUP BY  |    |1       |41          |
+|1 |└─TABLE FULL SCAN|t1  |100     |39          |
+=================================================
+Outputs & filters:
+-------------------------------------
+  0 - output([T_FUN_COUNT_SUM(T_FUN_COUNT(*))]), filter(nil), rowset=256
+      group(nil), agg_func([T_FUN_COUNT_SUM(T_FUN_COUNT(*))])
+  1 - output([T_FUN_COUNT(*)]), filter([(2) = (t1.c2)]), rowset=256
+      access([t1.c2]), partitions(p0)
+      is_index_back=false, is_global_index=false, filter_before_indexback[false], 
+      range_key([t1.__pk_increment]), range(MIN ; MAX)always true, 
+      pushdown_aggregation([T_FUN_COUNT(*)])
+explain select /*+ NO_REWRITE */ count(*) from t1 where c0 in (1,2,3,7) AND c0 in (4,5);
+Query Plan
+=================================================
+|ID|OPERATOR         |NAME|EST.ROWS|EST.TIME(us)|
+-------------------------------------------------
+|0 |SCALAR GROUP BY  |    |1       |46          |
+|1 |└─TABLE FULL SCAN|t1  |200     |42          |
+=================================================
+Outputs & filters:
+-------------------------------------
+  0 - output([T_FUN_COUNT_SUM(T_FUN_COUNT(*))]), filter(nil), rowset=256
+      group(nil), agg_func([T_FUN_COUNT_SUM(T_FUN_COUNT(*))])
+  1 - output([T_FUN_COUNT(*)]), filter([t1.c0 IN (4, 5)], [t1.c0 IN (1, 2, 3, 7)]), rowset=256
+      access([t1.c0]), partitions(p0)
+      is_index_back=false, is_global_index=false, filter_before_indexback[false,false], 
+      range_key([t1.__pk_increment]), range(MIN ; MAX)always true, 
+      pushdown_aggregation([T_FUN_COUNT(*)])
+explain select /*+ NO_REWRITE */ count(*) from t1 where (c0,c1) in ((1,2), (3,4));
+Query Plan
+=================================================
+|ID|OPERATOR         |NAME|EST.ROWS|EST.TIME(us)|
+-------------------------------------------------
+|0 |SCALAR GROUP BY  |    |1       |61          |
+|1 |└─TABLE FULL SCAN|t1  |21      |61          |
+=================================================
+Outputs & filters:
+-------------------------------------
+  0 - output([T_FUN_COUNT_SUM(T_FUN_COUNT(*))]), filter(nil), rowset=256
+      group(nil), agg_func([T_FUN_COUNT_SUM(T_FUN_COUNT(*))])
+  1 - output([T_FUN_COUNT(*)]), filter([(t1.c0, t1.c1) IN ((1, 2), (3, 4))]), rowset=256
+      access([t1.c0], [t1.c1]), partitions(p0)
+      is_index_back=false, is_global_index=false, filter_before_indexback[false], 
+      range_key([t1.__pk_increment]), range(MIN ; MAX)always true, 
+      pushdown_aggregation([T_FUN_COUNT(*)])
+explain select /*+ NO_REWRITE */ count(*) from t1 where (c0,c1)=(1,2) AND 3 in (c0,c1,c2);
+Query Plan
+=================================================
+|ID|OPERATOR         |NAME|EST.ROWS|EST.TIME(us)|
+-------------------------------------------------
+|0 |SCALAR GROUP BY  |    |1       |84          |
+|1 |└─TABLE FULL SCAN|t1  |2       |84          |
+=================================================
+Outputs & filters:
+-------------------------------------
+  0 - output([T_FUN_COUNT_SUM(T_FUN_COUNT(*))]), filter(nil), rowset=16
+      group(nil), agg_func([T_FUN_COUNT_SUM(T_FUN_COUNT(*))])
+  1 - output([T_FUN_COUNT(*)]), filter([3 IN (t1.c2)], [(t1.c0, t1.c1) = (1, 2)]), rowset=16
+      access([t1.c0], [t1.c1], [t1.c2]), partitions(p0)
+      is_index_back=false, is_global_index=false, filter_before_indexback[false,false], 
+      range_key([t1.__pk_increment]), range(MIN ; MAX)always true, 
+      pushdown_aggregation([T_FUN_COUNT(*)])
+explain select /*+ NO_REWRITE */ count(*) from t1 where (c0,c1)=(1,2) AND c0 in (7,3);
+Query Plan
+=================================================
+|ID|OPERATOR         |NAME|EST.ROWS|EST.TIME(us)|
+-------------------------------------------------
+|0 |SCALAR GROUP BY  |    |1       |61          |
+|1 |└─TABLE FULL SCAN|t1  |11      |61          |
+=================================================
+Outputs & filters:
+-------------------------------------
+  0 - output([T_FUN_COUNT_SUM(T_FUN_COUNT(*))]), filter(nil), rowset=16
+      group(nil), agg_func([T_FUN_COUNT_SUM(T_FUN_COUNT(*))])
+  1 - output([T_FUN_COUNT(*)]), filter([t1.c0 IN (7, 3)], [(t1.c0, t1.c1) = (1, 2)]), rowset=16
+      access([t1.c0], [t1.c1]), partitions(p0)
+      is_index_back=false, is_global_index=false, filter_before_indexback[false,false], 
+      range_key([t1.__pk_increment]), range(MIN ; MAX)always true, 
+      pushdown_aggregation([T_FUN_COUNT(*)])
+explain select /*+ NO_REWRITE */ count(*) from t1 where (c0,c1)=(1,2) AND c0>=9 AND c1<=2;
+Query Plan
+=================================================
+|ID|OPERATOR         |NAME|EST.ROWS|EST.TIME(us)|
+-------------------------------------------------
+|0 |SCALAR GROUP BY  |    |1       |62          |
+|1 |└─TABLE FULL SCAN|t1  |11      |62          |
+=================================================
+Outputs & filters:
+-------------------------------------
+  0 - output([T_FUN_COUNT_SUM(T_FUN_COUNT(*))]), filter(nil), rowset=16
+      group(nil), agg_func([T_FUN_COUNT_SUM(T_FUN_COUNT(*))])
+  1 - output([T_FUN_COUNT(*)]), filter([t1.c0 >= 9], [t1.c1 <= 2], [(t1.c0, t1.c1) = (1, 2)]), rowset=16
+      access([t1.c0], [t1.c1]), partitions(p0)
+      is_index_back=false, is_global_index=false, filter_before_indexback[false,false,false], 
+      range_key([t1.__pk_increment]), range(MIN ; MAX)always true, 
+      pushdown_aggregation([T_FUN_COUNT(*)])
+explain select /*+ NO_REWRITE */ count(*) from t1 where c1>=5 and c2=1;
+Query Plan
+=================================================
+|ID|OPERATOR         |NAME|EST.ROWS|EST.TIME(us)|
+-------------------------------------------------
+|0 |SCALAR GROUP BY  |    |1       |71          |
+|1 |└─TABLE FULL SCAN|t1  |55      |70          |
+=================================================
+Outputs & filters:
+-------------------------------------
+  0 - output([T_FUN_COUNT_SUM(T_FUN_COUNT(*))]), filter(nil), rowset=256
+      group(nil), agg_func([T_FUN_COUNT_SUM(T_FUN_COUNT(*))])
+  1 - output([T_FUN_COUNT(*)]), filter([t1.c2 = 1], [t1.c1 >= 5]), rowset=256
+      access([t1.c1], [t1.c2]), partitions(p0)
+      is_index_back=false, is_global_index=false, filter_before_indexback[false,false], 
+      range_key([t1.__pk_increment]), range(MIN ; MAX)always true, 
+      pushdown_aggregation([T_FUN_COUNT(*)])
+explain select /*+ NO_REWRITE */ count(*) from t1 where c1>0 and c1<0 and c2=1;
+Query Plan
+=================================================
+|ID|OPERATOR         |NAME|EST.ROWS|EST.TIME(us)|
+-------------------------------------------------
+|0 |SCALAR GROUP BY  |    |1       |68          |
+|1 |└─TABLE FULL SCAN|t1  |0       |68          |
+=================================================
+Outputs & filters:
+-------------------------------------
+  0 - output([T_FUN_COUNT_SUM(T_FUN_COUNT(*))]), filter(nil), rowset=16
+      group(nil), agg_func([T_FUN_COUNT_SUM(T_FUN_COUNT(*))])
+  1 - output([T_FUN_COUNT(*)]), filter([t1.c1 < 0], [t1.c2 = 1], [t1.c1 > 0]), rowset=16
+      access([t1.c1], [t1.c2]), partitions(p0)
+      is_index_back=false, is_global_index=false, filter_before_indexback[false,false,false], 
+      range_key([t1.__pk_increment]), range(MIN ; MAX)always true, 
+      pushdown_aggregation([T_FUN_COUNT(*)])
+explain select /*+ NO_REWRITE */ count(*) from t1 where c0 >> 12 & 15 in (0,1);
+Query Plan
+=================================================
+|ID|OPERATOR         |NAME|EST.ROWS|EST.TIME(us)|
+-------------------------------------------------
+|0 |SCALAR GROUP BY  |    |1       |45          |
+|1 |└─TABLE FULL SCAN|t1  |200     |41          |
+=================================================
+Outputs & filters:
+-------------------------------------
+  0 - output([T_FUN_COUNT_SUM(T_FUN_COUNT(*))]), filter(nil), rowset=256
+      group(nil), agg_func([T_FUN_COUNT_SUM(T_FUN_COUNT(*))])
+  1 - output([T_FUN_COUNT(*)]), filter([(T_OP_BIT_AND, cast((T_OP_BIT_RIGHT_SHIFT, cast(t1.c0, BIGINT(-1, 0)), 12), BIGINT(-1, 0)), 15) IN (0, 1)]), rowset=256
+      access([t1.c0]), partitions(p0)
+      is_index_back=false, is_global_index=false, filter_before_indexback[false], 
+      range_key([t1.__pk_increment]), range(MIN ; MAX)always true, 
+      pushdown_aggregation([T_FUN_COUNT(*)])

--- a/tools/deploy/mysql_test/test_suite/optimizer/t/precise_redundant_predicate.test
+++ b/tools/deploy/mysql_test/test_suite/optimizer/t/precise_redundant_predicate.test
@@ -1,0 +1,59 @@
+# owner: xiaoyen.xy
+# tags: optimizer 
+# 测试冗余单谓词选择率估计过小的场景
+
+# 创建表
+--disable_warnings
+DROP TABLE IF EXISTS t1;
+CREATE TABLE t1 (
+    c0 INT,
+    c1 INT,
+    c2 INT,
+    c3 INT
+);
+
+# 填充表
+DROP PROCEDURE IF EXISTS FillTable;
+DELIMITER //;
+CREATE PROCEDURE FillTable()
+BEGIN
+  DECLARE i INT DEFAULT 0;
+  WHILE i < 1000 DO
+    INSERT INTO t1 (c0, c1, c2, c3) VALUES (MOD(i, 10), MOD(i, 10), MOD(i, 10), MOD(i, 10));
+    SET i = i + 1;
+  END WHILE;
+END //
+
+DELIMITER ;//
+CALL FillTable();
+--enable_warnings
+
+# 禁用动态采样功能
+SET GLOBAL optimizer_dynamic_sampling = 0;
+# 开启 SQL 扩展功能
+alter system set enable_sql_extension = true;
+# 分析表 t1 的统计信息
+call dbms_stats.delete_table_stats('test', 't1');
+call dbms_stats.gather_table_stats('test', 't1', method_opt=>'FOR ALL COLUMNS SIZE 1');
+# 记录日志
+set ob_enable_show_trace=true;set ob_log_level='debug';
+
+
+# 测试场景
+# EqualSelEstimator
+explain select /*+ NO_REWRITE */ count(*) from t1 where (c2,2,c2)=(1,c2,3) and c2=2;
+explain select /*+ NO_REWRITE */ count(*) from t1 where c2=4 and c2=4;
+explain select /*+ NO_REWRITE */ count(*) from t1 where (c2,c3)=((2,3)) and (c2,c3)=(2,3);
+# InSelEstimator
+explain select /*+ NO_REWRITE */ count(*) from t1 where (2,2) in ((c2,c2));
+explain select /*+ NO_REWRITE */ count(*) from t1 where c0 in (1,2,3,7) AND c0 in (4,5);
+explain select /*+ NO_REWRITE */ count(*) from t1 where (c0,c1) in ((1,2), (3,4));
+# EqualSelEstimator & InSelEstimator
+explain select /*+ NO_REWRITE */ count(*) from t1 where (c0,c1)=(1,2) AND 3 in (c0,c1,c2);
+explain select /*+ NO_REWRITE */ count(*) from t1 where (c0,c1)=(1,2) AND c0 in (7,3);
+# EqualSelEstimator & RangeSelEstimator
+explain select /*+ NO_REWRITE */ count(*) from t1 where (c0,c1)=(1,2) AND c0>=9 AND c1<=2;
+explain select /*+ NO_REWRITE */ count(*) from t1 where c1>=5 and c2=1;
+explain select /*+ NO_REWRITE */ count(*) from t1 where c1>0 and c1<0 and c2=1;
+# Other situation
+explain select /*+ NO_REWRITE */ count(*) from t1 where c0 >> 12 & 15 in (0,1);


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase**! 
Please read the [How to Contribute](https://github.com/oceanbase/oceanbase/wiki/how_to_contribute) document **BEFORE** filling this PR.

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description

<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->
当查询中出现重复谓词，而查询改写模块没起作用的时候，由于ob假设谓词间是独立的，直接将重复谓词的选择率相乘，会引起选择率估计过小，从而导致计划严重走偏耗时过长的情况。

例如： `select /*+no_rewrite*/ count(*) from t where (c0,c1)=(1,1) and (c1,c2)=(1,1)`
正确的计算选择率的结果是`1/(ndv*ndv*ndv)`，但是这里会将四个选择率独立相乘，即`1/(ndv*ndv*ndv*ndv)`
### Solution Description
不使用参数窥探的情况下，将表达式中的谓词进行抽取与合并，最后即可以将两个待计算选择率的表达式转化成更加精准计算的形式
<!-- Please clearly and consice descipt the solution. -->

### Passed Regressions

<!-- Unittest, mysql test or test it manually? -->

### Upgrade Compatibility

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

### Other Information

<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
