### PR TITLE
Faster utf8 well_formed_len

### DIFF
--- a/deps/oblib/src/lib/charset/ob_ctype_utf8.cc
+++ b/deps/oblib/src/lib/charset/ob_ctype_utf8.cc
@@ -24,9 +24,147 @@
 #include "lib/charset/mb_wc.h"
 #include "lib/utility/ob_macro_utils.h"
 #include "lib/charset/ob_ctype_utf8_tab.h"
+#include "common/ob_target_specific.h"
+#if OB_USE_MULTITARGET_CODE
+#include <emmintrin.h>
 #include <immintrin.h>
+#endif
+
 #define IS_CONTINUATION_BYTE(code) (((code) >> 6) == 0x02)
-int utf8_naive(const unsigned char *data, int len)
+#define RET_ERR_IDX 1 
+
+static int ob_valid_mbcharlen_utf8mb3(const uchar *s, const uchar *e)
+{
+  uchar c;
+  ob_charset_assert(s < e);
+  c= s[0];
+  if (c < 0x80)
+    return 1;
+  if (c < 0xc2)
+    return OB_CS_ILSEQ;
+  if (c < 0xe0)
+  {
+    if (s+2 > e) /* We need 2 characters */
+      return OB_CS_TOOSMALL2;
+    if (!(IS_CONTINUATION_BYTE(s[1])))
+      return OB_CS_ILSEQ;
+    return 2;
+  }
+  ob_charset_assert(c < 0xf0);
+  if (s+3 > e) /* We need 3 characters */
+    return OB_CS_TOOSMALL3;
+  if (!(IS_CONTINUATION_BYTE(s[1]) && IS_CONTINUATION_BYTE(s[2]) && (c >= 0xe1 || s[1] >= 0xa0)))
+    return OB_CS_ILSEQ;
+  return 3;
+}
+
+static int ob_valid_mbcharlen_utf8mb4(const ObCharsetInfo *cs __attribute__((unused)), const uchar *s, const uchar *e)
+{
+  uchar c;
+  if (s >= e)
+    return OB_CS_TOOSMALL;
+  c= s[0];
+  if (c < 0xf0)
+    return ob_valid_mbcharlen_utf8mb3(s, e);
+  if (c < 0xf5)
+  {
+    if (s + 4 > e) /* We need 4 characters */
+      return OB_CS_TOOSMALL4;
+    if (!(IS_CONTINUATION_BYTE(s[1]) &&
+          IS_CONTINUATION_BYTE(s[2]) &&
+          IS_CONTINUATION_BYTE(s[3]) &&
+          (c >= 0xf1 || s[1] >= 0x90) &&
+          (c <= 0xf3 || s[1] <= 0x8F)))
+      return OB_CS_ILSEQ;
+    return 4;
+  }
+  return OB_CS_ILSEQ;
+}
+
+static uint ob_ismbchar_utf8mb4(const ObCharsetInfo *cs, const char *b, const char *e)
+{
+  int res= ob_valid_mbcharlen_utf8mb4(cs, (const uchar*)b, (const uchar*)e);
+  return (res > 1) ? res : 0;
+}
+
+
+static uint ob_mbcharlen_utf8mb4(const ObCharsetInfo *cs __attribute__((unused)), uint c)
+{
+  if (c < 0x80)
+    return 1;
+  if (c < 0xc2)
+    return 0; /* Illegal mb head */
+  if (c < 0xe0)
+    return 2;
+  if (c < 0xf0)
+    return 3;
+  if (c < 0xf8)
+    return 4;
+  return 0; /* Illegal mb head */;
+}
+
+static inline int ascii_u64(const uint8_t *data, int len)
+{
+    uint8_t orall = 0;
+
+    if (len >= 16) {
+
+        uint64_t or1 = 0, or2 = 0;
+        const uint8_t *data2 = data+8;
+
+        do {
+            or1 |= *(const uint64_t *)data;
+            or2 |= *(const uint64_t *)data2;
+            data += 16;
+            data2 += 16;
+            len -= 16;
+        } while (len >= 16);
+
+        /*
+         * Idea from Benny Halevy <bhalevy@scylladb.com>
+         * - 7-th bit set   ==> orall = !(non-zero) - 1 = 0 - 1 = 0xFF
+         * - 7-th bit clear ==> orall = !0 - 1          = 1 - 1 = 0x00
+         */
+        orall = !((or1 | or2) & 0x8080808080808080ULL) - 1;
+    }
+
+    while (len--)
+        orall |= *data++;
+
+    return orall < 0x80;
+}
+
+
+OB_DECLARE_DEFAULT_CODE(
+  static size_t ob_well_formed_len_utf8mb4(const ObCharsetInfo *cs,
+                                         const char *b, const char *e,
+                                         size_t pos, int *error)
+  {
+    int len = (int)(e-b);
+    if (OB_UNLIKELY(len <= 0)) {
+      return 0;
+    } else if (len>=15 && ascii_u64((const uint8_t *)b, len)) {
+      return (size_t)len;
+    }
+    const char *b_start= b;
+    *error= 0;
+    while (pos)
+    {
+      int mb_len;
+      if ((mb_len= ob_valid_mbcharlen_utf8mb4(cs, (uchar*) b, (uchar*) e)) <= 0)
+      {
+        *error= b < e ? 1 : 0;
+        break;
+      }
+      b+= mb_len;
+      pos--;
+    }
+    return (size_t) (b - b_start);
+    
+  }
+)
+
+static int inline utf8_naive(const unsigned char *data, int len)
 {
     int err_pos = 1;
 
@@ -88,7 +226,8 @@ int utf8_naive(const unsigned char *data, int len)
     return 0;
 }
 
-static const int8_t _first_len_tbl[] = {
+OB_DECLARE_SSE42_SPECIFIC_CODE(
+  static const int8_t _first_len_tbl[] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 2, 3,
 };
 
@@ -141,7 +280,6 @@ static const int8_t _ef_fe_tbl[] = {
     0, 3, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 };
 
-#define RET_ERR_IDX 1   /* Define 1 to return index of first error char */
 
 /* 5x faster than naive method */
 /* Return 0 - success, -1 - error, >0 - first error char(if RET_ERR_IDX = 1) */
@@ -314,102 +452,303 @@ do_naive:
     return utf8_naive(data, len);
 #endif
 }
-static int ob_valid_mbcharlen_utf8mb3(const uchar *s, const uchar *e)
+static size_t ob_well_formed_len_utf8mb4(const ObCharsetInfo *cs,
+                                         const char *b, const char *e,
+                                         size_t pos, int *error)
 {
-  uchar c;
-  ob_charset_assert(s < e);
-  c= s[0];
-  if (c < 0x80)
-    return 1;
-  if (c < 0xc2)
-    return OB_CS_ILSEQ;
-  if (c < 0xe0)
-  {
-    if (s+2 > e) /* We need 2 characters */
-      return OB_CS_TOOSMALL2;
-    if (!(IS_CONTINUATION_BYTE(s[1])))
-      return OB_CS_ILSEQ;
-    return 2;
+  int len = (int)(e-b);
+  if (OB_UNLIKELY(len <= 0)) {
+    return 0;
   }
-  ob_charset_assert(c < 0xf0);
-  if (s+3 > e) /* We need 3 characters */
-    return OB_CS_TOOSMALL3;
-  if (!(IS_CONTINUATION_BYTE(s[1]) && IS_CONTINUATION_BYTE(s[2]) && (c >= 0xe1 || s[1] >= 0xa0)))
-    return OB_CS_ILSEQ;
-  return 3;
-}
-
-static int ob_valid_mbcharlen_utf8mb4(const ObCharsetInfo *cs __attribute__((unused)), const uchar *s, const uchar *e)
-{
-  uchar c;
-  if (s >= e)
-    return OB_CS_TOOSMALL;
-  c= s[0];
-  if (c < 0xf0)
-    return ob_valid_mbcharlen_utf8mb3(s, e);
-  if (c < 0xf5)
-  {
-    if (s + 4 > e) /* We need 4 characters */
-      return OB_CS_TOOSMALL4;
-    if (!(IS_CONTINUATION_BYTE(s[1]) &&
-          IS_CONTINUATION_BYTE(s[2]) &&
-          IS_CONTINUATION_BYTE(s[3]) &&
-          (c >= 0xf1 || s[1] >= 0x90) &&
-          (c <= 0xf3 || s[1] <= 0x8F)))
-      return OB_CS_ILSEQ;
-    return 4;
+  int err_pos = utf8_range((unsigned char *)b, len);
+  if (err_pos == 0) {
+    return len;
+  } else {
+    if (err_pos > 0)
+      return err_pos - 1;
   }
-  return OB_CS_ILSEQ;
+  return 0;
+  
 }
 
-static uint ob_ismbchar_utf8mb4(const ObCharsetInfo *cs, const char *b, const char *e)
-{
-  int res= ob_valid_mbcharlen_utf8mb4(cs, (const uchar*)b, (const uchar*)e);
-  return (res > 1) ? res : 0;
+)
+
+OB_DECLARE_AVX2_SPECIFIC_CODE(
+  /*
+ * Map high nibble of "First Byte" to legal character length minus 1
+ * 0x00 ~ 0xBF --> 0
+ * 0xC0 ~ 0xDF --> 1
+ * 0xE0 ~ 0xEF --> 2
+ * 0xF0 ~ 0xFF --> 3
+ */
+static const int8_t _first_len_tbl[] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 2, 3,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 2, 3,
+};
+
+/* Map "First Byte" to 8-th item of range table (0xC2 ~ 0xF4) */
+static const int8_t _first_range_tbl[] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 8, 8, 8,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 8, 8, 8,
+};
+
+/*
+ * Range table, map range index to min and max values
+ * Index 0    : 00 ~ 7F (First Byte, ascii)
+ * Index 1,2,3: 80 ~ BF (Second, Third, Fourth Byte)
+ * Index 4    : A0 ~ BF (Second Byte after E0)
+ * Index 5    : 80 ~ 9F (Second Byte after ED)
+ * Index 6    : 90 ~ BF (Second Byte after F0)
+ * Index 7    : 80 ~ 8F (Second Byte after F4)
+ * Index 8    : C2 ~ F4 (First Byte, non ascii)
+ * Index 9~15 : illegal: i >= 127 && i <= -128
+ */
+static const uint8_t _range_min_tbl[] = {
+    0x00, 0x80, 0x80, 0x80, 0xA0, 0x80, 0x90, 0x80,
+    0xC2, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F,
+    0x00, 0x80, 0x80, 0x80, 0xA0, 0x80, 0x90, 0x80,
+    0xC2, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F,
+};
+static const uint8_t _range_max_tbl[] = {
+    0x7F, 0xBF, 0xBF, 0xBF, 0xBF, 0x9F, 0xBF, 0x8F,
+    0xF4, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
+    0x7F, 0xBF, 0xBF, 0xBF, 0xBF, 0x9F, 0xBF, 0x8F,
+    0xF4, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
+};
+
+/*
+ * Tables for fast handling of four special First Bytes(E0,ED,F0,F4), after
+ * which the Second Byte are not 80~BF. It contains "range index adjustment".
+ * +------------+---------------+------------------+----------------+
+ * | First Byte | original range| range adjustment | adjusted range |
+ * +------------+---------------+------------------+----------------+
+ * | E0         | 2             | 2                | 4              |
+ * +------------+---------------+------------------+----------------+
+ * | ED         | 2             | 3                | 5              |
+ * +------------+---------------+------------------+----------------+
+ * | F0         | 3             | 3                | 6              |
+ * +------------+---------------+------------------+----------------+
+ * | F4         | 4             | 4                | 8              |
+ * +------------+---------------+------------------+----------------+
+ */
+/* index1 -> E0, index14 -> ED */
+static const int8_t _df_ee_tbl[] = {
+    0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0,
+    0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0,
+};
+/* index1 -> F0, index5 -> F4 */
+static const int8_t _ef_fe_tbl[] = {
+    0, 3, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 3, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+};
+
+static inline __m256i push_last_byte_of_a_to_b(__m256i a, __m256i b) {
+  return _mm256_alignr_epi8(b, _mm256_permute2x128_si256(a, b, 0x21), 15);
 }
 
+static inline __m256i push_last_2bytes_of_a_to_b(__m256i a, __m256i b) {
+  return _mm256_alignr_epi8(b, _mm256_permute2x128_si256(a, b, 0x21), 14);
+}
 
-static uint ob_mbcharlen_utf8mb4(const ObCharsetInfo *cs __attribute__((unused)), uint c)
+static inline __m256i push_last_3bytes_of_a_to_b(__m256i a, __m256i b) {
+  return _mm256_alignr_epi8(b, _mm256_permute2x128_si256(a, b, 0x21), 13);
+}
+
+/* 5x faster than naive method */
+/* Return 0 - success, -1 - error, >0 - first error char(if RET_ERR_IDX = 1) */
+int utf8_range_avx2(const unsigned char *data, int len)
 {
-  if (c < 0x80)
-    return 1;
-  if (c < 0xc2)
-    return 0; /* Illegal mb head */
-  if (c < 0xe0)
-    return 2;
-  if (c < 0xf0)
-    return 3;
-  if (c < 0xf8)
-    return 4;
-  return 0; /* Illegal mb head */;
+#if  RET_ERR_IDX
+    int err_pos = 1;
+#endif
+
+    if (len >= 32) {
+        __m256i prev_input = _mm256_set1_epi8(0);
+        __m256i prev_first_len = _mm256_set1_epi8(0);
+
+        /* Cached tables */
+        const __m256i first_len_tbl =
+            _mm256_loadu_si256((const __m256i *)_first_len_tbl);
+        const __m256i first_range_tbl =
+            _mm256_loadu_si256((const __m256i *)_first_range_tbl);
+        const __m256i range_min_tbl =
+            _mm256_loadu_si256((const __m256i *)_range_min_tbl);
+        const __m256i range_max_tbl =
+            _mm256_loadu_si256((const __m256i *)_range_max_tbl);
+        const __m256i df_ee_tbl =
+            _mm256_loadu_si256((const __m256i *)_df_ee_tbl);
+        const __m256i ef_fe_tbl =
+            _mm256_loadu_si256((const __m256i *)_ef_fe_tbl);
+
+#if !RET_ERR_IDX
+        __m256i error1 = _mm256_set1_epi8(0);
+        __m256i error2 = _mm256_set1_epi8(0);
+#endif
+
+        while (len >= 32) {
+            const __m256i input = _mm256_loadu_si256((const __m256i *)data);
+
+            /* high_nibbles = input >> 4 */
+            const __m256i high_nibbles =
+                _mm256_and_si256(_mm256_srli_epi16(input, 4), _mm256_set1_epi8(0x0F));
+
+            /* first_len = legal character length minus 1 */
+            /* 0 for 00~7F, 1 for C0~DF, 2 for E0~EF, 3 for F0~FF */
+            /* first_len = first_len_tbl[high_nibbles] */
+            __m256i first_len = _mm256_shuffle_epi8(first_len_tbl, high_nibbles);
+
+            /* First Byte: set range index to 8 for bytes within 0xC0 ~ 0xFF */
+            /* range = first_range_tbl[high_nibbles] */
+            __m256i range = _mm256_shuffle_epi8(first_range_tbl, high_nibbles);
+
+            /* Second Byte: set range index to first_len */
+            /* 0 for 00~7F, 1 for C0~DF, 2 for E0~EF, 3 for F0~FF */
+            /* range |= (first_len, prev_first_len) << 1 byte */
+            range = _mm256_or_si256(
+                    range, push_last_byte_of_a_to_b(prev_first_len, first_len));
+
+            /* Third Byte: set range index to saturate_sub(first_len, 1) */
+            /* 0 for 00~7F, 0 for C0~DF, 1 for E0~EF, 2 for F0~FF */
+            __m256i tmp1, tmp2;
+
+            /* tmp1 = (first_len, prev_first_len) << 2 bytes */
+            tmp1 = push_last_2bytes_of_a_to_b(prev_first_len, first_len);
+            /* tmp2 = saturate_sub(tmp1, 1) */
+            tmp2 = _mm256_subs_epu8(tmp1, _mm256_set1_epi8(1));
+
+            /* range |= tmp2 */
+            range = _mm256_or_si256(range, tmp2);
+
+            /* Fourth Byte: set range index to saturate_sub(first_len, 2) */
+            /* 0 for 00~7F, 0 for C0~DF, 0 for E0~EF, 1 for F0~FF */
+            /* tmp1 = (first_len, prev_first_len) << 3 bytes */
+            tmp1 = push_last_3bytes_of_a_to_b(prev_first_len, first_len);
+            /* tmp2 = saturate_sub(tmp1, 2) */
+            tmp2 = _mm256_subs_epu8(tmp1, _mm256_set1_epi8(2));
+            /* range |= tmp2 */
+            range = _mm256_or_si256(range, tmp2);
+
+            /*
+             * Now we have below range indices caluclated
+             * Correct cases:
+             * - 8 for C0~FF
+             * - 3 for 1st byte after F0~FF
+             * - 2 for 1st byte after E0~EF or 2nd byte after F0~FF
+             * - 1 for 1st byte after C0~DF or 2nd byte after E0~EF or
+             *         3rd byte after F0~FF
+             * - 0 for others
+             * Error cases:
+             *   9,10,11 if non ascii First Byte overlaps
+             *   E.g., F1 80 C2 90 --> 8 3 10 2, where 10 indicates error
+             */
+
+            /* Adjust Second Byte range for special First Bytes(E0,ED,F0,F4) */
+            /* Overlaps lead to index 9~15, which are illegal in range table */
+            __m256i shift1, pos, range2;
+            /* shift1 = (input, prev_input) << 1 byte */
+            shift1 = push_last_byte_of_a_to_b(prev_input, input);
+            pos = _mm256_sub_epi8(shift1, _mm256_set1_epi8(0xEF));
+            /*
+             * shift1:  | EF  F0 ... FE | FF  00  ... ...  DE | DF  E0 ... EE |
+             * pos:     | 0   1      15 | 16  17           239| 240 241    255|
+             * pos-240: | 0   0      0  | 0   0            0  | 0   1      15 |
+             * pos+112: | 112 113    127|       >= 128        |     >= 128    |
+             */
+            tmp1 = _mm256_subs_epu8(pos, _mm256_set1_epi8(static_cast<uint8_t>(240)));
+            range2 = _mm256_shuffle_epi8(df_ee_tbl, tmp1);
+            tmp2 = _mm256_adds_epu8(pos, _mm256_set1_epi8(112));
+            range2 = _mm256_add_epi8(range2, _mm256_shuffle_epi8(ef_fe_tbl, tmp2));
+
+            range = _mm256_add_epi8(range, range2);
+
+            /* Load min and max values per calculated range index */
+            __m256i minv = _mm256_shuffle_epi8(range_min_tbl, range);
+            __m256i maxv = _mm256_shuffle_epi8(range_max_tbl, range);
+
+            /* Check value range */
+#if RET_ERR_IDX
+            __m256i error = _mm256_cmpgt_epi8(minv, input);
+            error = _mm256_or_si256(error, _mm256_cmpgt_epi8(input, maxv));
+            /* 5% performance drop from this conditional branch */
+            if (!_mm256_testz_si256(error, error))
+                break;
+#else
+            error1 = _mm256_or_si256(error1, _mm256_cmpgt_epi8(minv, input));
+            error2 = _mm256_or_si256(error2, _mm256_cmpgt_epi8(input, maxv));
+#endif
+
+            prev_input = input;
+            prev_first_len = first_len;
+
+            data += 32;
+            len -= 32;
+#if RET_ERR_IDX
+            err_pos += 32;
+#endif
+        }
+
+#if RET_ERR_IDX
+        /* Error in first 16 bytes */
+        if (err_pos == 1)
+            goto do_naive;
+#else
+        __m256i error = _mm256_or_si256(error1, error2);
+        if (!_mm256_testz_si256(error, error))
+            return -1;
+#endif
+
+        /* Find previous token (not 80~BF) */
+        int32_t token4 = _mm256_extract_epi32(prev_input, 7);
+        const int8_t *token = (const int8_t *)&token4;
+        int lookahead = 0;
+        if (token[3] > (int8_t)0xBF)
+            lookahead = 1;
+        else if (token[2] > (int8_t)0xBF)
+            lookahead = 2;
+        else if (token[1] > (int8_t)0xBF)
+            lookahead = 3;
+
+        data -= lookahead;
+        len += lookahead;
+#if RET_ERR_IDX
+        err_pos -= lookahead;
+#endif
+    }
+
+    /* Check remaining bytes with naive method */
+#if RET_ERR_IDX
+    int err_pos2;
+do_naive:
+    err_pos2 = utf8_naive(data, len);
+    if (err_pos2)
+        return err_pos + err_pos2 - 1;
+    return 0;
+#else
+    return utf8_naive(data, len);
+#endif
 }
 
 static size_t ob_well_formed_len_utf8mb4(const ObCharsetInfo *cs,
                                          const char *b, const char *e,
                                          size_t pos, int *error)
 {
-  // const char *b_start= b;
-  // *error= 0;
-  // while (pos)
-  // {
-  //   int mb_len;
-  //   if ((mb_len= ob_valid_mbcharlen_utf8mb4(cs, (uchar*) b, (uchar*) e)) <= 0)
-  //   {
-  //     *error= b < e ? 1 : 0;
-  //     break;
-  //   }
-  //   b+= mb_len;
-  //   pos--;
-  // }
-  // return (size_t) (b - b_start);
-  int ret = utf8_range((const unsigned char *)b, (int)(e - b));
-  if (OB_UNLIKELY(ret>0)) {
-    *error = 1;
-    return ret-1;
-  } else {
-    return (size_t)(e-b);
+  int len = (int)(e-b);
+  if (OB_UNLIKELY(len <= 0)) {
+    return 0;
   }
+  int err_pos = utf8_range_avx2((unsigned char *)b, len);
+  if (err_pos == 0) {
+    return len;
+  } else {
+    if (err_pos > 0)
+      return err_pos - 1;
+  }
+  return 0;
+  
 }
+)
+
+
 
 static int ob_mb_wc_utf8mb4(const ObCharsetInfo *cs __attribute__((unused)),
                  ob_wc_t * pwc, const uchar *s, const uchar *e)
@@ -1243,7 +1582,13 @@ ObCharsetHandler ob_charset_utf8mb4_handler=
   ob_numchars_mb,
   ob_charpos_mb,
   ob_max_bytes_charpos_mb,
-  ob_well_formed_len_utf8mb4,
+#if OB_USE_MULTITARGET_CODE
+  oceanbase::common::is_arch_supported(oceanbase::ObTargetArch::SSE42)? \
+  specific::sse42::ob_well_formed_len_utf8mb4: \
+  oceanbase::common::is_arch_supported(oceanbase::ObTargetArch::AVX2)? specific::avx2::ob_well_formed_len_utf8mb4:specific::normal::ob_well_formed_len_utf8mb4,
+#else
+  specific::normal::ob_well_formed_len_utf8mb4,
+#endif
   ob_lengthsp_8bit,
   ob_mb_wc_utf8mb4,
   ob_wc_mb_utf8mb4,

--- a/deps/oblib/src/lib/charset/ob_ctype_utf8.cc
+++ b/deps/oblib/src/lib/charset/ob_ctype_utf8.cc
@@ -24,9 +24,296 @@
 #include "lib/charset/mb_wc.h"
 #include "lib/utility/ob_macro_utils.h"
 #include "lib/charset/ob_ctype_utf8_tab.h"
-
+#include <immintrin.h>
 #define IS_CONTINUATION_BYTE(code) (((code) >> 6) == 0x02)
+int utf8_naive(const unsigned char *data, int len)
+{
+    int err_pos = 1;
 
+    while (len) {
+        int bytes;
+        const unsigned char byte1 = data[0];
+
+        /* 00..7F */
+        if (byte1 <= 0x7F) {
+            bytes = 1;
+        /* C2..DF, 80..BF */
+        } else if (len >= 2 && byte1 >= 0xC2 && byte1 <= 0xDF &&
+                (signed char)data[1] <= (signed char)0xBF) {
+            bytes = 2;
+        } else if (len >= 3) {
+            const unsigned char byte2 = data[1];
+
+            /* Is byte2, byte3 between 0x80 ~ 0xBF */
+            const int byte2_ok = (signed char)byte2 <= (signed char)0xBF;
+            const int byte3_ok = (signed char)data[2] <= (signed char)0xBF;
+
+            if (byte2_ok && byte3_ok &&
+                     /* E0, A0..BF, 80..BF */
+                    ((byte1 == 0xE0 && byte2 >= 0xA0) ||
+                     /* E1..EC, 80..BF, 80..BF */
+                     (byte1 >= 0xE1 && byte1 <= 0xEC) ||
+                     /* ED, 80..9F, 80..BF */
+                     (byte1 == 0xED && byte2 <= 0x9F) ||
+                     /* EE..EF, 80..BF, 80..BF */
+                     (byte1 >= 0xEE && byte1 <= 0xEF))) {
+                bytes = 3;
+            } else if (len >= 4) {
+                /* Is byte4 between 0x80 ~ 0xBF */
+                const int byte4_ok = (signed char)data[3] <= (signed char)0xBF;
+
+                if (byte2_ok && byte3_ok && byte4_ok &&
+                         /* F0, 90..BF, 80..BF, 80..BF */
+                        ((byte1 == 0xF0 && byte2 >= 0x90) ||
+                         /* F1..F3, 80..BF, 80..BF, 80..BF */
+                         (byte1 >= 0xF1 && byte1 <= 0xF3) ||
+                         /* F4, 80..8F, 80..BF, 80..BF */
+                         (byte1 == 0xF4 && byte2 <= 0x8F))) {
+                    bytes = 4;
+                } else {
+                    return err_pos;
+                }
+            } else {
+                return err_pos;
+            }
+        } else {
+            return err_pos;
+        }
+
+        len -= bytes;
+        err_pos += bytes;
+        data += bytes;
+    }
+
+    return 0;
+}
+
+static const int8_t _first_len_tbl[] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 2, 3,
+};
+
+/* Map "First Byte" to 8-th item of range table (0xC2 ~ 0xF4) */
+static const int8_t _first_range_tbl[] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 8, 8, 8,
+};
+
+/*
+ * Range table, map range index to min and max values
+ * Index 0    : 00 ~ 7F (First Byte, ascii)
+ * Index 1,2,3: 80 ~ BF (Second, Third, Fourth Byte)
+ * Index 4    : A0 ~ BF (Second Byte after E0)
+ * Index 5    : 80 ~ 9F (Second Byte after ED)
+ * Index 6    : 90 ~ BF (Second Byte after F0)
+ * Index 7    : 80 ~ 8F (Second Byte after F4)
+ * Index 8    : C2 ~ F4 (First Byte, non ascii)
+ * Index 9~15 : illegal: i >= 127 && i <= -128
+ */
+static const uint8_t _range_min_tbl[] = {
+    0x00, 0x80, 0x80, 0x80, 0xA0, 0x80, 0x90, 0x80,
+    0xC2, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F,
+};
+static const uint8_t _range_max_tbl[] = {
+    0x7F, 0xBF, 0xBF, 0xBF, 0xBF, 0x9F, 0xBF, 0x8F,
+    0xF4, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
+};
+
+/*
+ * Tables for fast handling of four special First Bytes(E0,ED,F0,F4), after
+ * which the Second Byte are not 80~BF. It contains "range index adjustment".
+ * +------------+---------------+------------------+----------------+
+ * | First Byte | original range| range adjustment | adjusted range |
+ * +------------+---------------+------------------+----------------+
+ * | E0         | 2             | 2                | 4              |
+ * +------------+---------------+------------------+----------------+
+ * | ED         | 2             | 3                | 5              |
+ * +------------+---------------+------------------+----------------+
+ * | F0         | 3             | 3                | 6              |
+ * +------------+---------------+------------------+----------------+
+ * | F4         | 4             | 4                | 8              |
+ * +------------+---------------+------------------+----------------+
+ */
+/* index1 -> E0, index14 -> ED */
+static const int8_t _df_ee_tbl[] = {
+    0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0,
+};
+/* index1 -> F0, index5 -> F4 */
+static const int8_t _ef_fe_tbl[] = {
+    0, 3, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+};
+
+#define RET_ERR_IDX 1   /* Define 1 to return index of first error char */
+
+/* 5x faster than naive method */
+/* Return 0 - success, -1 - error, >0 - first error char(if RET_ERR_IDX = 1) */
+int utf8_range(const unsigned char *data, int len)
+{
+#if  RET_ERR_IDX
+    int err_pos = 1;
+#endif
+
+    if (len >= 16) {
+        __m128i prev_input = _mm_set1_epi8(0);
+        __m128i prev_first_len = _mm_set1_epi8(0);
+
+        /* Cached tables */
+        const __m128i first_len_tbl =
+            _mm_loadu_si128((const __m128i *)_first_len_tbl);
+        const __m128i first_range_tbl =
+            _mm_loadu_si128((const __m128i *)_first_range_tbl);
+        const __m128i range_min_tbl =
+            _mm_loadu_si128((const __m128i *)_range_min_tbl);
+        const __m128i range_max_tbl =
+            _mm_loadu_si128((const __m128i *)_range_max_tbl);
+        const __m128i df_ee_tbl =
+            _mm_loadu_si128((const __m128i *)_df_ee_tbl);
+        const __m128i ef_fe_tbl =
+            _mm_loadu_si128((const __m128i *)_ef_fe_tbl);
+
+        __m128i error = _mm_set1_epi8(0);
+
+        while (len >= 16) {
+            const __m128i input = _mm_loadu_si128((const __m128i *)data);
+
+            /* high_nibbles = input >> 4 */
+            const __m128i high_nibbles =
+                _mm_and_si128(_mm_srli_epi16(input, 4), _mm_set1_epi8(0x0F));
+
+            /* first_len = legal character length minus 1 */
+            /* 0 for 00~7F, 1 for C0~DF, 2 for E0~EF, 3 for F0~FF */
+            /* first_len = first_len_tbl[high_nibbles] */
+            __m128i first_len = _mm_shuffle_epi8(first_len_tbl, high_nibbles);
+
+            /* First Byte: set range index to 8 for bytes within 0xC0 ~ 0xFF */
+            /* range = first_range_tbl[high_nibbles] */
+            __m128i range = _mm_shuffle_epi8(first_range_tbl, high_nibbles);
+
+            /* Second Byte: set range index to first_len */
+            /* 0 for 00~7F, 1 for C0~DF, 2 for E0~EF, 3 for F0~FF */
+            /* range |= (first_len, prev_first_len) << 1 byte */
+            range = _mm_or_si128(
+                    range, _mm_alignr_epi8(first_len, prev_first_len, 15));
+
+            /* Third Byte: set range index to saturate_sub(first_len, 1) */
+            /* 0 for 00~7F, 0 for C0~DF, 1 for E0~EF, 2 for F0~FF */
+            __m128i tmp;
+            /* tmp = (first_len, prev_first_len) << 2 bytes */
+            tmp = _mm_alignr_epi8(first_len, prev_first_len, 14);
+            /* tmp = saturate_sub(tmp, 1) */
+            tmp = _mm_subs_epu8(tmp, _mm_set1_epi8(1));
+            /* range |= tmp */
+            range = _mm_or_si128(range, tmp);
+
+            /* Fourth Byte: set range index to saturate_sub(first_len, 2) */
+            /* 0 for 00~7F, 0 for C0~DF, 0 for E0~EF, 1 for F0~FF */
+            /* tmp = (first_len, prev_first_len) << 3 bytes */
+            tmp = _mm_alignr_epi8(first_len, prev_first_len, 13);
+            /* tmp = saturate_sub(tmp, 2) */
+            tmp = _mm_subs_epu8(tmp, _mm_set1_epi8(2));
+            /* range |= tmp */
+            range = _mm_or_si128(range, tmp);
+
+            /*
+             * Now we have below range indices caluclated
+             * Correct cases:
+             * - 8 for C0~FF
+             * - 3 for 1st byte after F0~FF
+             * - 2 for 1st byte after E0~EF or 2nd byte after F0~FF
+             * - 1 for 1st byte after C0~DF or 2nd byte after E0~EF or
+             *         3rd byte after F0~FF
+             * - 0 for others
+             * Error cases:
+             *   9,10,11 if non ascii First Byte overlaps
+             *   E.g., F1 80 C2 90 --> 8 3 10 2, where 10 indicates error
+             */
+
+            /* Adjust Second Byte range for special First Bytes(E0,ED,F0,F4) */
+            /* Overlaps lead to index 9~15, which are illegal in range table */
+            __m128i shift1, pos, range2;
+            /* shift1 = (input, prev_input) << 1 byte */
+            shift1 = _mm_alignr_epi8(input, prev_input, 15);
+            pos = _mm_sub_epi8(shift1, _mm_set1_epi8(0xEF));
+            /*
+             * shift1:  | EF  F0 ... FE | FF  00  ... ...  DE | DF  E0 ... EE |
+             * pos:     | 0   1      15 | 16  17           239| 240 241    255|
+             * pos-240: | 0   0      0  | 0   0            0  | 0   1      15 |
+             * pos+112: | 112 113    127|       >= 128        |     >= 128    |
+             */
+            tmp = _mm_subs_epu8(pos, _mm_set1_epi8(0xF0));
+            range2 = _mm_shuffle_epi8(df_ee_tbl, tmp);
+            tmp = _mm_adds_epu8(pos, _mm_set1_epi8(0x70));
+            range2 = _mm_add_epi8(range2, _mm_shuffle_epi8(ef_fe_tbl, tmp));
+
+            range = _mm_add_epi8(range, range2);
+
+            /* Load min and max values per calculated range index */
+            __m128i minv = _mm_shuffle_epi8(range_min_tbl, range);
+            __m128i maxv = _mm_shuffle_epi8(range_max_tbl, range);
+
+            /* Check value range */
+#if RET_ERR_IDX
+            error = _mm_cmplt_epi8(input, minv);
+            error = _mm_or_si128(error, _mm_cmpgt_epi8(input, maxv));
+            /* 5% performance drop from this conditional branch */
+            if (!_mm_testz_si128(error, error))
+                break;
+#else
+            /* error |= (input < minv) | (input > maxv) */
+            tmp = _mm_or_si128(
+                      _mm_cmplt_epi8(input, minv),
+                      _mm_cmpgt_epi8(input, maxv)
+                  );
+            error = _mm_or_si128(error, tmp);
+#endif
+
+            prev_input = input;
+            prev_first_len = first_len;
+
+            data += 16;
+            len -= 16;
+#if RET_ERR_IDX
+            err_pos += 16;
+#endif
+        }
+
+#if RET_ERR_IDX
+        /* Error in first 16 bytes */
+        if (err_pos == 1)
+            goto do_naive;
+#else
+        if (!_mm_testz_si128(error, error))
+            return -1;
+#endif
+
+        /* Find previous token (not 80~BF) */
+        int32_t token4 = _mm_extract_epi32(prev_input, 3);
+        const int8_t *token = (const int8_t *)&token4;
+        int lookahead = 0;
+        if (token[3] > (int8_t)0xBF)
+            lookahead = 1;
+        else if (token[2] > (int8_t)0xBF)
+            lookahead = 2;
+        else if (token[1] > (int8_t)0xBF)
+            lookahead = 3;
+
+        data -= lookahead;
+        len += lookahead;
+#if RET_ERR_IDX
+        err_pos -= lookahead;
+#endif
+    }
+
+    /* Check remaining bytes with naive method */
+#if RET_ERR_IDX
+    int err_pos2;
+do_naive:
+    err_pos2 = utf8_naive(data, len);
+    if (err_pos2)
+        return err_pos + err_pos2 - 1;
+    return 0;
+#else
+    return utf8_naive(data, len);
+#endif
+}
 static int ob_valid_mbcharlen_utf8mb3(const uchar *s, const uchar *e)
 {
   uchar c;
@@ -101,20 +388,27 @@ static size_t ob_well_formed_len_utf8mb4(const ObCharsetInfo *cs,
                                          const char *b, const char *e,
                                          size_t pos, int *error)
 {
-  const char *b_start= b;
-  *error= 0;
-  while (pos)
-  {
-    int mb_len;
-    if ((mb_len= ob_valid_mbcharlen_utf8mb4(cs, (uchar*) b, (uchar*) e)) <= 0)
-    {
-      *error= b < e ? 1 : 0;
-      break;
-    }
-    b+= mb_len;
-    pos--;
+  // const char *b_start= b;
+  // *error= 0;
+  // while (pos)
+  // {
+  //   int mb_len;
+  //   if ((mb_len= ob_valid_mbcharlen_utf8mb4(cs, (uchar*) b, (uchar*) e)) <= 0)
+  //   {
+  //     *error= b < e ? 1 : 0;
+  //     break;
+  //   }
+  //   b+= mb_len;
+  //   pos--;
+  // }
+  // return (size_t) (b - b_start);
+  int ret = utf8_range((const unsigned char *)b, (int)(e - b));
+  if (OB_UNLIKELY(ret>0)) {
+    *error = 1;
+    return ret-1;
+  } else {
+    return (size_t)(e-b);
   }
-  return (size_t) (b - b_start);
 }
 
 static int ob_mb_wc_utf8mb4(const ObCharsetInfo *cs __attribute__((unused)),

--- a/deps/oblib/src/lib/charset/ob_ctype_utf8.cc
+++ b/deps/oblib/src/lib/charset/ob_ctype_utf8.cc
@@ -140,12 +140,12 @@ OB_DECLARE_DEFAULT_CODE(
                                          const char *b, const char *e,
                                          size_t pos, int *error)
   {
-    int len = (int)(e-b);
-    if (OB_UNLIKELY(len <= 0)) {
-      return 0;
-    } else if (len>=15 && ascii_u64((const uint8_t *)b, len)) {
-      return (size_t)len;
-    }
+    // int len = (int)(e-b);
+    // if (OB_UNLIKELY(len <= 0)) {
+    //   return 0;
+    // } else if (len>=15 && ascii_u64((const uint8_t *)b, len)) {
+    //   return (size_t)len;
+    // }
     const char *b_start= b;
     *error= 0;
     while (pos)
@@ -492,8 +492,11 @@ static size_t ob_well_formed_len_utf8mb4(const ObCharsetInfo *cs,
   if (err_pos == 0) {
     return len;
   } else {
-    if (err_pos > 0)
+    if (err_pos > 0){
+      *error = 1;
       return err_pos - 1;
+    }
+      
   }
   return 0;
   
@@ -795,8 +798,10 @@ static size_t ob_well_formed_len_utf8mb4(const ObCharsetInfo *cs,
   if (err_pos == 0) {
     return len;
   } else {
-    if (err_pos > 0)
+    if (err_pos > 0){
+      *error = 1;
       return err_pos - 1;
+    }
   }
   return 0;
   

--- a/deps/oblib/unittest/lib/charset/test_charset.cpp
+++ b/deps/oblib/unittest/lib/charset/test_charset.cpp
@@ -349,6 +349,99 @@ TEST_F(TestCharset, well_formed_length)
   ASSERT_TRUE(OB_INVALID_ARGUMENT == ret);
 }
 
+TEST_F(TestCharset, well_formed_length_performance)
+{
+  int all_tests = 10000;
+  char data[100][INT16_MAX];
+  int test_data_bytes = 0;
+  ObCollationType cs_type =  CS_TYPE_UTF8MB4_GENERAL_CI;
+  int64_t well_formed_length = 0;
+  int64_t time_start = 0;
+  int64_t time_dur = 0;
+  int status = 0;
+  auto start_timer = [&]() { time_start = ObTimeUtility::current_time();};
+  auto end_timer = [&]() {
+    time_dur = ObTimeUtility::current_time() - time_start;
+    /*don't change this fprintf func unless you know what you are doing*/
+    fprintf(stdout, "==> speed:%ldM/s, time is %ld", (test_data_bytes*all_tests >> 12) * (1000000>>6) / (time_dur<<2), time_dur);
+  };
+  auto prepare_data = [&]() {
+    for (int i = 0 ; i < 100 ; i++) {
+        if(i%status == 0){
+            for (int j = 0 ; j < INT16_MAX ; j++) {
+                data[i][j] = 1;
+            }
+            
+        }
+        else {
+            for (int j = 0 ; j < INT16_MAX ; j+=4) {
+                data[i][j] = 0xf0;
+                data[i][j+1] = 0x9f;
+                data[i][j+2] = 0x91;
+                data[i][j+3] = 0x8b;
+
+            }
+        }
+    }
+  };
+  status = INT16_MAX;
+  prepare_data();
+  fprintf(stdout, "\nNo ascci \n");
+  for (test_data_bytes = 4; test_data_bytes <= INT16_MAX ; test_data_bytes *=2 ) {
+    fprintf(stdout, "\n# For charset: %s, TestDataLen: %d\n", ObCharset::charset_name(cs_type), test_data_bytes);
+    start_timer();
+    for(int i = 0 ; i < all_tests ; i ++){
+      ObCharset::well_formed_len(cs_type, data[i%100], test_data_bytes, well_formed_length);
+    }
+    end_timer();
+  }
+  status = 1;
+  prepare_data();
+  fprintf(stdout, "\nAll Ascii \n");
+  for (test_data_bytes = 4; test_data_bytes <= INT16_MAX ; test_data_bytes *=2 ) {
+    fprintf(stdout, "\n# For charset: %s, TestDataLen: %d\n", ObCharset::charset_name(cs_type), test_data_bytes);
+    start_timer();
+    for(int i = 0 ; i < all_tests ; i ++){
+      ObCharset::well_formed_len(cs_type, data[i%100], test_data_bytes, well_formed_length);
+    }
+    end_timer();
+  }
+  status = 2;
+  prepare_data();
+  fprintf(stdout, "\n0.5 Ascii \n");
+  for (test_data_bytes = 4; test_data_bytes <= INT16_MAX ; test_data_bytes *=2 ) {
+    fprintf(stdout, "\n# For charset: %s, TestDataLen: %d\n", ObCharset::charset_name(cs_type), test_data_bytes);
+    start_timer();
+    for(int i = 0 ; i < all_tests ; i ++){
+      ObCharset::well_formed_len(cs_type, data[i%100], test_data_bytes, well_formed_length);
+    }
+    end_timer();
+  }
+  status = 3;
+  prepare_data();
+  fprintf(stdout, "\n0.33 Ascii \n");
+  for (test_data_bytes = 4; test_data_bytes <= INT16_MAX ; test_data_bytes *=2 ) {
+    fprintf(stdout, "\n# For charset: %s, TestDataLen: %d\n", ObCharset::charset_name(cs_type), test_data_bytes);
+    start_timer();
+    for(int i = 0 ; i < all_tests ; i ++){
+      ObCharset::well_formed_len(cs_type, data[i%100], test_data_bytes, well_formed_length);
+    }
+    end_timer();
+  }
+  status = 4;
+  prepare_data();
+  fprintf(stdout, "\n0.25 Ascii \n");
+  for (test_data_bytes = 4; test_data_bytes <= INT16_MAX ; test_data_bytes *=2 ) {
+    fprintf(stdout, "\n# For charset: %s, TestDataLen: %d\n", ObCharset::charset_name(cs_type), test_data_bytes);
+    start_timer();
+    for(int i = 0 ; i < all_tests ; i ++){
+      ObCharset::well_formed_len(cs_type, data[i%100], test_data_bytes, well_formed_length);
+    }
+    end_timer();
+  }
+  
+}
+
 TEST_F(TestCharset, test_max_byte_char_pos)
 {
   int ret = OB_SUCCESS;

--- a/tools/deploy/mysql_test/test_suite/charset/r/well_formed_len.result
+++ b/tools/deploy/mysql_test/test_suite/charset/r/well_formed_len.result
@@ -1,0 +1,27 @@
+drop table if exists test_table;
+Warnings:
+Note	1051	Unknown table 'test.test_table'
+CREATE TABLE test_table (id INT PRIMARY KEY AUTO_INCREMENT, content varchar(255)) CHARACTER SET utf8mb4;
+INSERT INTO test_table (content) VALUES (0x3126e8a4b3db8530e9ab8ee58296e9bb9ec2ad32ce99ce953acebcceac64d88ce5a88ddb9adbb8daaed983e7b493da9ae8b6b4);
+INSERT INTO test_table (content) VALUES (0xcf8fce85c2bf36cea1c3abdaa4e7a8ba50c3912ae6858eceafdabdc38bc2a9e8a1bfc2aee4be96e9979dd8a6ce9dc392c2b2);
+INSERT INTO test_table (content) VALUES (0xcfa4ce8bcf95d8a6cea8cfacda8ed885cf84c2b2d99bcf9fdbae655ac383483536e88daad8b8dba4cfa7da93d89ccfa4e782af);
+INSERT INTO test_table (content) VALUES (0xcfa6e5bf86cdb7da97e6a482c3b5e7a99ccfbb4367c3bbce98dabdcdb9e8908ec38531cea0d8aad9a3c38ad988da8bd891c2a3);
+INSERT INTO test_table (content) VALUES (0xdbadcfbae7b7a35fcf8ce78f97cdb73ada89cdb0c3a8da814ec399e8bdac3ccdb7c3bfc2bcd8a5c3a7dba2ce85c3b63fc3bf);
+INSERT INTO test_table (content) VALUES (0xce917a78d88847807e70f574e9ba9cff7ddbb0eda080c39fd88a49f5feda9780c0feffdb88cf8fdbbb80c080c2b9e8a79ff5);
+ERROR HY000: Incorrect string value
+INSERT INTO test_table (content) VALUES (0xffe58eaee7ae8a80d9a8e4beb9d88bcf9e80eda08080e88183d98fcfaac080eda080c2afc080c39fff2a7ec0cdb1bfffffe89695);
+ERROR HY000: Incorrect string value
+INSERT INTO test_table (content) VALUES (0xdba2da81ffbf80334fc1c066c2aeeda080e58b80696eda95bffebff5f5c055cfa4db94eda080c1f5e5bd94d8b457c08067ff);
+ERROR HY000: Incorrect string value
+INSERT INTO test_table (content) VALUES (0xe5a59ec2bafffe2ec0eda080c1eda08051ce8eeda080e9be89c3b7eda0807ee5bf98e596adcf9fffdbafc0febfc080dbb6cfbc);
+ERROR HY000: Incorrect string value
+INSERT INTO test_table (content) VALUES (0xc08080e79cb1c08036f5c3a0c3bcc385fffec1feffe583aece8bf5c2a1fee7ba8fd9b3c1c1c0802acfbbceb42ceda080f5db9f);
+ERROR HY000: Incorrect string value
+select * from test_table;
+id	content
+1	1&褳ۅ0髎傖點­2ΙΕ:μάd،娍ۚ۸ڮك紓ښ趴
+2	Ϗ΅¿6Ρëڤ稺PÑ*慎ίڽË©衿®侖闝ئΝÒ²
+3	Ϥ΋ϕئΨϬڎ؅τ²ٛϟۮeZÃH56荪ظۤϧړ؜Ϥ炯
+4	Ϧ忆ͷڗ椂õ穜ϻCgûΘڽ͹萎Å1Πت٣Êوڋؑ£
+5	ۭϺ緣_ό珗ͷ:ډͰèځNÙ转<ͷÿ¼إçۢ΅ö?ÿ
+DROP TABLE test_table;

--- a/tools/deploy/mysql_test/test_suite/charset/t/well_formed_len.test
+++ b/tools/deploy/mysql_test/test_suite/charset/t/well_formed_len.test
@@ -1,0 +1,26 @@
+--disable_query_log
+set @@session.explicit_defaults_for_timestamp=off;
+--enable_query_log
+# owner: jim.wzh
+# owner group: SQL
+drop table if exists test_table;
+# valid utf8 string
+CREATE TABLE test_table (id INT PRIMARY KEY AUTO_INCREMENT, content varchar(255)) CHARACTER SET utf8mb4;
+INSERT INTO test_table (content) VALUES (0x3126e8a4b3db8530e9ab8ee58296e9bb9ec2ad32ce99ce953acebcceac64d88ce5a88ddb9adbb8daaed983e7b493da9ae8b6b4);
+INSERT INTO test_table (content) VALUES (0xcf8fce85c2bf36cea1c3abdaa4e7a8ba50c3912ae6858eceafdabdc38bc2a9e8a1bfc2aee4be96e9979dd8a6ce9dc392c2b2);
+INSERT INTO test_table (content) VALUES (0xcfa4ce8bcf95d8a6cea8cfacda8ed885cf84c2b2d99bcf9fdbae655ac383483536e88daad8b8dba4cfa7da93d89ccfa4e782af);
+INSERT INTO test_table (content) VALUES (0xcfa6e5bf86cdb7da97e6a482c3b5e7a99ccfbb4367c3bbce98dabdcdb9e8908ec38531cea0d8aad9a3c38ad988da8bd891c2a3);
+INSERT INTO test_table (content) VALUES (0xdbadcfbae7b7a35fcf8ce78f97cdb73ada89cdb0c3a8da814ec399e8bdac3ccdb7c3bfc2bcd8a5c3a7dba2ce85c3b63fc3bf);
+#invalid utf8 string
+--error 1366
+INSERT INTO test_table (content) VALUES (0xce917a78d88847807e70f574e9ba9cff7ddbb0eda080c39fd88a49f5feda9780c0feffdb88cf8fdbbb80c080c2b9e8a79ff5);
+--error 1366
+INSERT INTO test_table (content) VALUES (0xffe58eaee7ae8a80d9a8e4beb9d88bcf9e80eda08080e88183d98fcfaac080eda080c2afc080c39fff2a7ec0cdb1bfffffe89695);
+--error 1366
+INSERT INTO test_table (content) VALUES (0xdba2da81ffbf80334fc1c066c2aeeda080e58b80696eda95bffebff5f5c055cfa4db94eda080c1f5e5bd94d8b457c08067ff);
+--error 1366
+INSERT INTO test_table (content) VALUES (0xe5a59ec2bafffe2ec0eda080c1eda08051ce8eeda080e9be89c3b7eda0807ee5bf98e596adcf9fffdbafc0febfc080dbb6cfbc);
+--error 1366
+INSERT INTO test_table (content) VALUES (0xc08080e79cb1c08036f5c3a0c3bcc385fffec1feffe583aece8bf5c2a1fee7ba8fd9b3c1c1c0802acfbbceb42ceda080f5db9f);
+select * from test_table;
+DROP TABLE test_table;


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase**! 
Please read the [How to Contribute](https://github.com/oceanbase/oceanbase/wiki/how_to_contribute) document **BEFORE** filling this PR.

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description

<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->
accelerate the computation of well_formed_len function of utf8
### Solution Description

<!-- Please clearly and consice descipt the solution. -->
use simd instruction to accelerate computation of well_formed_len in utf8, and accelerate with prior ascii judgement when simd instruction is not supported
### Passed Regressions

<!-- Unittest, mysql test or test it manually? -->

### Upgrade Compatibility

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

### Other Information

<!-- Any information helping to review this pull request. -->
#### test result with different datasets
##### origin 
| data length/ascii  percent | 0             | 0.25 | 0.33 | 0.5  | 1    |
| -------------------------- | ------------- | ---- | ---- | ---- | ---- |
| 4 **(bytes)**              | 138 **(Mb/s)** | 152  | 145  | 139  | 137  |
| 8                          | 239           | 249  | 231  | 211  | 193  |
| 16                         | 330           | 327  | 315  | 280  | 235  |
| 32                         | 437           | 351  | 361  | 315  | 241  |
| 64                         | 506           | 418  | 379  | 357  | 266  |
| 128                        | 525           | 440  | 402  | 372  | 281  |
| 256                        | 593           | 461  | 446  | 386  | 288  |
| 512                        | 598           | 477  | 440  | 393  | 293  |
| 1024                       | 607           | 483  | 437  | 395  | 293  |
| 2048                       | 613           | 482  | 435  | 396  | 296  |
| 4096                       | 600           | 490  | 447  | 398  | 299  |
| 8192                       | 617           | 478  | 447  | 405  | 298  |
| 16384                      | 616           | 490  | 448  | 404  | 290  |
##### origin with ascii optimization
| data  length/ascii percent | 0             | 0.25 | 0.33 | 0.5  | 1     |
| -------------------------- | ------------- | ---- | ---- | ---- | ----- |
| 4 **(bytes)**              | 252 **(Mb/s)** | 251  | 237  | 237  | 225   |
| 8                          | 351           | 356  | 340  | 350  | 332   |
| 16                         | 464           | 574  | 621  | 743  | 1711  |
| 32                         | 558           | 620  | 775  | 955  | 3173  |
| 64                         | 619           | 744  | 779  | 1095 | 5489  |
| 128                        | 616           | 777  | 834  | 1131 | 7569  |
| 256                        | 651           | 835  | 921  | 1218 | 11625 |
| 512                        | 665           | 860  | 963  | 1270 | 16385 |
| 1024                       | 674           | 878  | 986  | 1292 | 19337 |
| 2048                       | 679           | 883  | 996  | 1302 | 21773 |
| 4096                       | 679           | 883  | 997  | 1302 | 23059 |
| 8192                       | 680           | 884  | 989  | 1302 | 22456 |
| 16384                      | 679           | 881  | 993  | 1286 | 20717 |
##### sse method
| data  length/ascii percent | 0             | 0.25 | 0.33 | 0.5  | 1     |
| -------------------------- | ------------- | ---- | ---- | ---- | ----- |
| 4 **(bytes)**              | 222 **(Mb/s)** | 242  | 256  | 264  | 338   |
| 8                          | 350           | 378  | 407  | 434  | 575   |
| 16                         | 725           | 946  | 958  | 1154 | 1603  |
| 32                         | 1264          | 1531 | 1570 | 1869 | 3276  |
| 64                         | 1916          | 2290 | 2467 | 2834 | 6623  |
| 128                        | 2408          | 3009 | 3125 | 3773 | 11079 |
| 256                        | 2899          | 3699 | 3963 | 4749 | 17193 |
| 512                        | 3102          | 3850 | 4426 | 5413 | 24660 |
| 1024                       | 3186          | 4220 | 4697 | 6103 | 27901 |
| 2048                       | 3349          | 4315 | 4788 | 6056 | 36643 |
| 4096                       | 3306          | 4437 | 4890 | 5838 | 37887 |
| 8192                       | 2811          | 4354 | 4850 | 5877 | 34416 |
| 16384                      | 3265          | 4084 | 4542 | 5630 | 22540 |
##### avx2 method
| data length/ascii  percent | 0             | 0.25 | 0.33 | 0.5  | 1     |
| -------------------------- | ------------- | ---- | ---- | ---- | ----- |
| 4 **(bytes)**              | 218 **(Mb/s)** | 213  | 242  | 258  | 303   |
| 8                          | 335           | 374  | 372  | 399  | 549   |
| 16                         | 458           | 564  | 581  | 708  | 1638  |
| 32                         | 1391          | 1711 | 1813 | 2058 | 3241  |
| 64                         | 2153          | 2720 | 2821 | 3046 | 6347  |
| 128                        | 3348          | 4022 | 4261 | 5057 | 11284 |
| 256                        | 4223          | 5044 | 5717 | 6744 | 16721 |
| 512                        | 4892          | 5805 | 6725 | 7913 | 25299 |
| 1024                       | 5255          | 6532 | 7066 | 8926 | 28638 |
| 2048                       | 5478          | 6845 | 7477 | 9426 | 36303 |
| 4096                       | 5480          | 6366 | 7694 | 9278 | 38371 |
| 8192                       | 5477          | 6802 | 7646 | 9358 | 35886 |
| 16384                      | 5210          | 6395 | 7034 | 8448 | 24101 |
### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
