### PR TITLE
More agressive DFO scheduling strategy

### DIFF
--- a/src/share/parameter/ob_parameter_seed.ipp
+++ b/src/share/parameter/ob_parameter_seed.ipp
@@ -1227,9 +1227,9 @@ DEF_CAP(stack_size, OB_CLUSTER_PARAMETER, "512K", "[512K, 20M]",
 DEF_INT(__easy_memory_reserved_percentage, OB_CLUSTER_PARAMETER, "0", "[0,100]",
         "the percentage of easy memory reserved size. The default value is 0. Range: [0,100]",
         ObParameterAttr(Section::OBSERVER, Source::DEFAULT, EditLevel::DYNAMIC_EFFECTIVE));
-DEF_INT(_px_max_pipeline_depth, OB_CLUSTER_PARAMETER, "2", "[2,3]",
+DEF_INT(_px_max_pipeline_depth, OB_CLUSTER_PARAMETER, "2", "[2,5]",
         "max parallel execution pipeline depth, "
-        "range: [2,3]",
+        "range: [2,5]",
         ObParameterAttr(Section::TENANT, Source::DEFAULT, EditLevel::DYNAMIC_EFFECTIVE));
 //ssl
 DEF_BOOL(ssl_client_authentication, OB_CLUSTER_PARAMETER, "False",

--- a/src/sql/engine/basic/ob_material_op.cpp
+++ b/src/sql/engine/basic/ob_material_op.cpp
@@ -24,7 +24,7 @@ using namespace common;
 namespace sql
 {
 
-OB_SERIALIZE_MEMBER((ObMaterialSpec, ObOpSpec));
+OB_SERIALIZE_MEMBER((ObMaterialSpec, ObOpSpec), bypassable_);
 OB_SERIALIZE_MEMBER(ObMaterialOpInput, bypass_);
 
 int ObMaterialOp::inner_open()

--- a/src/sql/engine/basic/ob_material_op.h
+++ b/src/sql/engine/basic/ob_material_op.h
@@ -27,9 +27,21 @@ class ObMaterialSpec : public ObOpSpec
 {
 OB_UNIS_VERSION_V(1);
 public:
-  ObMaterialSpec(common::ObIAllocator &alloc, const ObPhyOperatorType type)
-    : ObOpSpec(alloc, type)
+  ObMaterialSpec(common::ObIAllocator &alloc, const ObPhyOperatorType type) :
+    ObOpSpec(alloc, type), bypassable_(false)
   {}
+
+  bool get_bypassable() const
+  {
+    return bypassable_;
+  }
+  void set_bypassable(bool bypassable)
+  {
+    bypassable_ = bypassable;
+  }
+
+private:
+  bool bypassable_;
 };
 
 class ObMaterialOpInput : public ObOpInput

--- a/src/sql/engine/basic/ob_material_vec_op.cpp
+++ b/src/sql/engine/basic/ob_material_vec_op.cpp
@@ -24,7 +24,7 @@ using namespace common;
 namespace sql
 {
 
-OB_SERIALIZE_MEMBER((ObMaterialVecSpec, ObOpSpec));
+OB_SERIALIZE_MEMBER((ObMaterialVecSpec, ObOpSpec), bypassable_);
 OB_SERIALIZE_MEMBER(ObMaterialVecOpInput, bypass_);
 
 int ObMaterialVecOp::inner_open()

--- a/src/sql/engine/basic/ob_material_vec_op.h
+++ b/src/sql/engine/basic/ob_material_vec_op.h
@@ -26,9 +26,21 @@ class ObMaterialVecSpec: public ObOpSpec
 {
 OB_UNIS_VERSION_V(1);
 public:
-  ObMaterialVecSpec(common::ObIAllocator &alloc, const ObPhyOperatorType type)
-    : ObOpSpec(alloc, type)
+  ObMaterialVecSpec(common::ObIAllocator &alloc, const ObPhyOperatorType type) :
+    ObOpSpec(alloc, type), bypassable_(false)
   {}
+
+  bool get_bypassable() const
+  {
+    return bypassable_;
+  }
+  void set_bypassable(bool bypassable)
+  {
+    bypassable_ = bypassable;
+  }
+
+private:
+  bool bypassable_;
 };
 
 class ObMaterialVecOpInput : public ObOpInput

--- a/src/sql/engine/ob_des_exec_context.cpp
+++ b/src/sql/engine/ob_des_exec_context.cpp
@@ -191,6 +191,7 @@ DEFINE_DESERIALIZE(ObDesExecContext)
   OB_UNIS_DECODE(task_executor_ctx_);
   OB_UNIS_DECODE(das_ctx_);
   OB_UNIS_DECODE(sql_ctx_);
+  OB_UNIS_DECODE(should_do_bypass_material_);
   if (OB_SUCC(ret)) {
     if (OB_FAIL(init_expr_op(phy_plan_ctx_->get_expr_op_size()))) {
       LOG_WARN("init exec context expr op failed", K(ret));

--- a/src/sql/engine/ob_exec_context.cpp
+++ b/src/sql/engine/ob_exec_context.cpp
@@ -132,6 +132,7 @@ ObExecContext::ObExecContext(ObIAllocator &allocator)
     dblink_snapshot_map_(),
     user_logging_ctx_(),
     is_online_stats_gathering_(false),
+    should_do_bypass_material_(true),
     lob_access_ctx_(nullptr)
 {
 }
@@ -1005,6 +1006,8 @@ DEFINE_SERIALIZE(ObExecContext)
     OB_UNIS_ENCODE(task_executor_ctx_);
     OB_UNIS_ENCODE(das_ctx_);
     OB_UNIS_ENCODE(*sql_ctx_);
+    
+    OB_UNIS_ENCODE(should_do_bypass_material_);
   }
   return ret;
 }
@@ -1036,6 +1039,8 @@ DEFINE_GET_SERIALIZE_SIZE(ObExecContext)
     OB_UNIS_ADD_LEN(task_executor_ctx_);
     OB_UNIS_ADD_LEN(das_ctx_);
     OB_UNIS_ADD_LEN(*sql_ctx_);
+
+    OB_UNIS_ADD_LEN(should_do_bypass_material_);
   }
   return len;
 }

--- a/src/sql/engine/ob_exec_context.h
+++ b/src/sql/engine/ob_exec_context.h
@@ -519,6 +519,8 @@ public:
   int get_local_var_array(int64_t local_var_array_id, const ObSolidifiedVarsContext *&var_array);
   void set_is_online_stats_gathering(bool v) { is_online_stats_gathering_ = v; }
   bool is_online_stats_gathering() const { return is_online_stats_gathering_; }
+  bool should_do_bypass_material() const { return should_do_bypass_material_; }
+  void set_should_do_bypass_material(bool v) { should_do_bypass_material_ = v; }
 
   int get_lob_access_ctx(ObLobAccessCtx *&lob_access_ctx);
 
@@ -700,6 +702,8 @@ protected:
   ObUserLoggingCtx user_logging_ctx_;
   // for online stats gathering
   bool is_online_stats_gathering_;
+  // for bypass material
+  bool should_do_bypass_material_;
   //---------------
 
   ObLobAccessCtx *lob_access_ctx_;

--- a/src/sql/engine/ob_physical_plan.cpp
+++ b/src/sql/engine/ob_physical_plan.cpp
@@ -1188,6 +1188,30 @@ int ObPhysicalPlan::set_minimal_worker_map(const common::hash::ObHashMap<ObAddr,
   return ret;
 }
 
+int ObPhysicalPlan::set_bypass_material_expected_worker_map(
+  const common::hash::ObHashMap<ObAddr, int64_t> &c)
+{
+  int ret = OB_SUCCESS;
+  if (OB_FAIL(assign_worker_map(stat_.bypass_material_expected_worker_map_, c))) {
+    LOG_WARN("set expected worker map failed", K(ret));
+  }
+  return ret;
+}
+const ObPlanStat::AddrMap &ObPhysicalPlan::get_bypass_material_expected_worker_map() const
+{
+  return stat_.bypass_material_expected_worker_map_;
+}
+
+int ObPhysicalPlan::set_bypass_material_minimal_worker_map(
+  const common::hash::ObHashMap<ObAddr, int64_t> &c)
+{
+  int ret = OB_SUCCESS;
+  if (OB_FAIL(assign_worker_map(stat_.bypass_material_minimal_worker_map_, c))) {
+    LOG_WARN("set minimal worker map failed", K(ret));
+  }
+  return ret;
+}
+
 int ObPhysicalPlan::assign_worker_map(ObPlanStat::AddrMap &worker_map, const common::hash::ObHashMap<ObAddr, int64_t> &c)
 {
   int ret = OB_SUCCESS;

--- a/src/sql/engine/ob_physical_plan.h
+++ b/src/sql/engine/ob_physical_plan.h
@@ -179,10 +179,18 @@ public:
   int64_t get_expected_worker_count() const { return stat_.expected_worker_count_; }
   void set_minimal_worker_count(int64_t c) { stat_.minimal_worker_count_ = c; }
   int64_t get_minimal_worker_count() const { return stat_.minimal_worker_count_; }
+  void set_bypass_material_expected_worker_count(int64_t c) { stat_.bypass_material_expected_worker_count_ = c; }
+  int64_t get_bypass_material_expected_worker_count() const { return stat_.bypass_material_expected_worker_count_; }
+  void set_bypass_material_minimal_worker_count(int64_t c) { stat_.bypass_material_minimal_worker_count_ = c; }
+  int64_t get_bypass_material_minimal_worker_count() const { return stat_.bypass_material_minimal_worker_count_; }
   int set_expected_worker_map(const common::hash::ObHashMap<ObAddr, int64_t> &c);
   const ObPlanStat::AddrMap& get_expected_worker_map() const;
   int set_minimal_worker_map(const common::hash::ObHashMap<ObAddr, int64_t> &c);
   const common::hash::ObHashMap<ObAddr, int64_t>& get_minimal_worker_map() const;
+  int set_bypass_material_expected_worker_map(const common::hash::ObHashMap<ObAddr, int64_t> &c);
+  const ObPlanStat::AddrMap& get_bypass_material_expected_worker_map() const;
+  int set_bypass_material_minimal_worker_map(const common::hash::ObHashMap<ObAddr, int64_t> &c);
+  const common::hash::ObHashMap<ObAddr, int64_t>& get_bypass_material_minimal_worker_map() const;
   int assign_worker_map(ObPlanStat::AddrMap &worker_map,
                         const common::hash::ObHashMap<ObAddr, int64_t> &c);
   const char* get_sql_id() const { return stat_.sql_id_.ptr(); }

--- a/src/sql/engine/px/exchange/ob_px_transmit_op.cpp
+++ b/src/sql/engine/px/exchange/ob_px_transmit_op.cpp
@@ -103,9 +103,9 @@ int ObPxTransmitOpInput::get_data_ch(ObPxTaskChSet &task_ch_set, int64_t timeout
 }
 //------------- end ObPxTransmitOpInput -------
 OB_SERIALIZE_MEMBER((ObPxTransmitSpec, ObTransmitSpec),
-    sample_type_, need_null_aware_shuffle_, tablet_id_expr_,
-    random_expr_, sampling_saving_row_, repartition_table_id_,
-    wf_hybrid_aggr_status_expr_, wf_hybrid_pby_exprs_cnt_array_);
+    sample_type_, need_null_aware_shuffle_, need_early_sched_, child_finish_for_early_sched_,
+    tablet_id_expr_, random_expr_, sampling_saving_row_,
+    repartition_table_id_, wf_hybrid_aggr_status_expr_, wf_hybrid_pby_exprs_cnt_array_);
 
 ObPxTransmitSpec::ObPxTransmitSpec(ObIAllocator &alloc, const ObPhyOperatorType type)
     : ObTransmitSpec(alloc, type),

--- a/src/sql/engine/px/exchange/ob_px_transmit_op.h
+++ b/src/sql/engine/px/exchange/ob_px_transmit_op.h
@@ -81,6 +81,9 @@ public:
   ObPxSampleType sample_type_;  //for range/pkey range
   // for null aware anti join, broadcast first line && null join key
   bool need_null_aware_shuffle_;
+  // true if the corresponding DFO could be early sched
+  bool need_early_sched_;
+  bool child_finish_for_early_sched_;
   // Fill the partition id to this expr for the above pdml or nlj partition pruning,
   ObExpr *tablet_id_expr_;
 

--- a/src/sql/engine/px/ob_dfo.h
+++ b/src/sql/engine/px/ob_dfo.h
@@ -44,16 +44,6 @@ class ObIDetectCallback;
 }
 namespace sql
 {
-
-enum class ObDfoState
-{
-  WAIT,
-  BLOCK,
-  RUNNING,
-  FINISH,
-  FAIL
-};
-
 #define SQC_TASK_START (1 << 0)
 #define SQC_TASK_EXIT  (1 << 1)
 
@@ -477,6 +467,7 @@ public:
     dop_(0),
     assigned_worker_cnt_(0),
     used_worker_cnt_(0),
+    pipeline_pos_(0),
     is_single_(false),
     is_root_dfo_(false),
     prealloced_receive_channel_(false),
@@ -538,6 +529,8 @@ public:
   int64_t get_assigned_worker_count() const { return assigned_worker_cnt_; }
   void set_used_worker_count(int64_t cnt) { used_worker_cnt_ = cnt; }
   int64_t get_used_worker_count() const { return used_worker_cnt_; }
+  void set_pipeline_pos(int64_t pos) { pipeline_pos_ = pos; }
+  int64_t get_pipeline_pos() const { return pipeline_pos_; }
   inline void set_single(const bool single) { is_single_ = single; }
   inline bool is_single() const { return is_single_; }
   inline void set_root_dfo(bool is_root) {is_root_dfo_ = is_root;}
@@ -597,20 +590,18 @@ public:
   inline int get_child_dfo(int64_t idx, ObDfo *&dfo) const { return child_dfos_.at(idx, dfo); }
   inline int64_t get_child_count() const { return child_dfos_.count(); }
   ObIArray<ObDfo*> &get_child_dfos() { return child_dfos_; }
+  const ObIArray<ObDfo*> &get_child_dfos() const { return child_dfos_; }
   inline bool has_child_dfo() const { return get_child_count() > 0; }
   // 本 DFO 即使优先调度，但可能依赖于另外的 DFO 调度才能推进本 DFO
   // 使用 depend_sibling 记录依赖的 DFO
   void set_depend_sibling(ObDfo *sibling) { depend_sibling_ = sibling; }
-  void set_has_depend_sibling(bool has_depend_sibling) { has_depend_sibling_ = has_depend_sibling; }
-  bool has_depend_sibling() const { return has_depend_sibling_; }
+  bool has_depend_sibling() const { return NULL != depend_sibling_; }
   ObDfo *depend_sibling() const { return depend_sibling_; }
   void set_parent(ObDfo *parent) { parent_ = parent; }
   bool has_parent() const { return NULL != parent_; }
   ObDfo *parent() const { return parent_; }
-  // 下面两个函数用于3层DFO 调度，使得HASH JOIN上面无需接MATERIAL算子，
-  // 流式输出结果集，被标记为 earlier_sched_ 的 dfo 被提前调度，直接消费JOIN结果
-  void set_earlier_sched(bool earlier) { earlier_sched_ = earlier; }
-  bool is_earlier_sched() const { return earlier_sched_; }
+  // DFOs will be marked as earlier sched to bypass MATERIAL operators
+  bool is_earlier_sched() const { return pipeline_pos_ > 1; }
   void set_dfo_id(int64_t dfo_id) { dfo_id_ = dfo_id; }
   int64_t get_dfo_id() const { return dfo_id_; }
 
@@ -705,6 +696,7 @@ public:
   }
   const ObString &query_sql() const { return query_sql_; }
   void set_query_sql(const ObString &query_sql) { query_sql_ = query_sql; }
+  int ready_to_earlier_sched(bool& ready_to_sched);
   TO_STRING_KV(K_(execution_id),
                K_(dfo_id),
                K_(is_active),
@@ -755,6 +747,32 @@ private:
   int64_t dop_;
   int64_t assigned_worker_cnt_;
   int64_t used_worker_cnt_;
+  /*
+       pipeline        pipeline_pos_
+
+    +------------+
+    |            |
+    |  ancestor  |          2 (earlier scheduled)
+    |            |
+    +------+-----+
+           ^
+           |
+           |
+    +------+-----+
+    |            |
+    |   parent   |          1
+    |            |
+    +------+-----+
+           ^
+           |
+           |
+    +------+-----+
+    |            |
+    |    child   |          0
+    |            |
+    +------------+
+   */
+  int64_t pipeline_pos_;
   // is_single 用于标记此dfo用一个线程去调度, 既可能在本地, 也可能在远程.
   // 如果此dfo包含table scan算子, 调度时将跟随table scan location调度
   // 如果此dfo不包含table scan算子, 调度时理论上可以在任意server去调度,

--- a/src/sql/engine/px/ob_dfo_mgr.cpp
+++ b/src/sql/engine/px/ob_dfo_mgr.cpp
@@ -67,16 +67,14 @@ int ObDfoSchedOrderGenerator::do_generate_sched_order(ObDfoMgr &dfo_mgr, ObDfo &
   return ret;
 }
 
-int ObDfoSchedDepthGenerator::generate_sched_depth(ObExecContext &exec_ctx,
-                                                   ObDfoMgr &dfo_mgr)
-{
+int ObDfoSchedDepthGenerator::generate_sched_depth(ObExecContext &exec_ctx, ObDfoMgr &dfo_mgr, const int64_t pipeline_depth) {
   int ret = OB_SUCCESS;
-  if (GCONF._px_max_pipeline_depth > 2) {
+  if (pipeline_depth > 2 && exec_ctx.should_do_bypass_material()) {
     ObDfo *dfo_tree = dfo_mgr.get_root_dfo();
     if (OB_ISNULL(dfo_tree)) {
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("NULL unexpected", K(ret));
-    } else if (OB_FAIL(do_generate_sched_depth(exec_ctx, dfo_mgr, *dfo_tree))) {
+    } else if (OB_FAIL(do_generate_sched_depth(exec_ctx, dfo_mgr, *dfo_tree, pipeline_depth))) {
       LOG_WARN("fail generate dfo edges", K(ret));
     }
   }
@@ -84,9 +82,8 @@ int ObDfoSchedDepthGenerator::generate_sched_depth(ObExecContext &exec_ctx,
 }
 
 // dfo_tree 后序遍历，定出哪些 dfo 可以做 material op bypass
-int ObDfoSchedDepthGenerator::do_generate_sched_depth(ObExecContext &exec_ctx,
-                                                      ObDfoMgr &dfo_mgr,
-                                                      ObDfo &parent)
+int ObDfoSchedDepthGenerator::do_generate_sched_depth(ObExecContext &exec_ctx, ObDfoMgr &dfo_mgr,
+                                                      ObDfo &parent, const int64_t pipeline_depth)
 {
   int ret = OB_SUCCESS;
   for (int64_t i = 0; OB_SUCC(ret) && i < parent.get_child_count(); ++i) {
@@ -95,24 +92,52 @@ int ObDfoSchedDepthGenerator::do_generate_sched_depth(ObExecContext &exec_ctx,
       LOG_WARN("fail get child dfo", K(i), K(parent), K(ret));
     } else if (OB_ISNULL(child)) {
       ret = OB_ERR_UNEXPECTED;
-    } else if (OB_FAIL(do_generate_sched_depth(exec_ctx, dfo_mgr, *child))) {
+    } else if (OB_FAIL(do_generate_sched_depth(exec_ctx, dfo_mgr, *child, pipeline_depth))) {
       LOG_WARN("fail do generate edge", K(*child), K(ret));
     } else {
-      bool need_earlier_sched = check_if_need_do_earlier_sched(*child);
+      bool need_earlier_sched = check_if_need_do_earlier_sched(*child, pipeline_depth);
       if (need_earlier_sched) {
-        // child 里面的 material 被改造成了 bypass 的，所以 parent 必须提前调度起来
-        // 同时，parent 中如果也有 material，必须标记为 block，不可 bypass。否则会 hang。
-        if (OB_FAIL(try_set_dfo_unblock(exec_ctx, *child))) {
-          // 既然 parent 被提前调度了，那么 parent 千万要阻塞
-          // 否则 parent 往外吐数据，就会卡住
+        // current pair of DFOs are earlier scheduled, block the parent DFO's material
+        // (parent DFO maybe unblocked later) to prevent unexpected hang
+        if (OB_FAIL(bypass_material(exec_ctx, child->get_root_op_spec()->get_child(), true))) {
           LOG_WARN("fail set dfo block", K(ret), K(*child), K(parent));
-        } else if (OB_FAIL(try_set_dfo_block(exec_ctx, parent))) {
-          // 既然 parent 被提前调度了，那么 parent 千万要阻塞
-          // 否则 parent 往外吐数据，就会卡住
+        } else if (OB_FAIL(bypass_material(exec_ctx, parent.get_root_op_spec()->get_child(), false))) {
           LOG_WARN("fail set dfo block", K(ret), K(*child), K(parent));
         } else {
-          parent.set_earlier_sched(true);
-          LOG_DEBUG("parent dfo can do earlier scheduling", K(*child), K(parent));
+          /*
+            pipeline        pipeline_pos_
+
+            +------------+
+            |            |
+            |  ancestor  |          2 (earlier scheduled)
+            |            |
+            +------+-----+
+                   ^
+                   |
+                   |
+            +------+-----+
+            |            |
+            |   parent   |          1
+            |            |
+            +------+-----+
+                   ^
+                   |
+                   |
+            +------+-----+
+            |            |
+            |    child   |          0
+            |            |
+            +------------+
+          */
+          if (child->get_pipeline_pos() == 0 && !child->is_leaf_dfo()) {
+            child->set_pipeline_pos(1);
+          }
+
+          // to match the optimizer, disable the early scheduling of root DFO
+          if (parent.get_pipeline_pos() == 0 && parent.get_dfo_id() != ObDfo::MAX_DFO_ID) {
+            parent.set_pipeline_pos(child->get_pipeline_pos() + 1);
+          }
+          LOG_TRACE("parent dfo can do earlier scheduling", K(child->get_dfo_id()), K(parent.get_dfo_id()));
         }
       }
     }
@@ -120,21 +145,70 @@ int ObDfoSchedDepthGenerator::do_generate_sched_depth(ObExecContext &exec_ctx,
   return ret;
 }
 
-bool ObDfoSchedDepthGenerator::check_if_need_do_earlier_sched(ObDfo &child)
+bool ObDfoSchedDepthGenerator::check_if_need_do_earlier_sched(ObDfo &dfo,
+                                                              const int64_t pipeline_depth)
 {
   bool do_earlier_sched = false;
-  if (child.is_earlier_sched() == false) {
-    const ObOpSpec *phy_op = child.get_root_op_spec();
-    if (OB_NOT_NULL(phy_op) && IS_PX_TRANSMIT(phy_op->type_)) {
-      phy_op = static_cast<const ObTransmitSpec *>(phy_op)->get_child();
-      do_earlier_sched = phy_op && (PHY_MATERIAL == phy_op->type_ || PHY_MATERIAL == phy_op->type_);
+  if (dfo.get_pipeline_pos() + 1 < pipeline_depth) {
+    const ObOpSpec *phy_op = dfo.get_root_op_spec();
+    const ObPxTransmitSpec *trans_op = NULL;
+    if (OB_NOT_NULL(phy_op) && IS_PX_TRANSMIT(phy_op->type_)
+        && OB_NOT_NULL(trans_op = static_cast<const ObPxTransmitSpec *>(phy_op))) {
+      do_earlier_sched = trans_op->need_early_sched_;
     }
-  } else {
-    // dfo (child) 是 earlier sched，那么可以知道 dfo 的 material 会阻塞对外吐数据.
-    // 此时 dfo 的 parent 没有必要提前调度，因为没有任何数据给它消费. parent 依靠
-    // 稍后的 2-DFO 普通调度即可。
   }
   return do_earlier_sched;
+}
+
+int ObDfoSchedDepthGenerator::bypass_material(ObExecContext &exec_ctx, const ObOpSpec *phy_op,
+                                              bool bypass)
+{
+  int ret = OB_SUCCESS;
+  if (OB_ISNULL(phy_op)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("phy_op is null", K(ret));
+  } else if (PHY_MATERIAL == phy_op->get_type()) {
+    const ObMaterialSpec *mat = static_cast<const ObMaterialSpec *>(phy_op);
+    ObOperatorKit *kit = exec_ctx.get_operator_kit(mat->id_);
+    if (OB_ISNULL(kit) || OB_ISNULL(kit->input_)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("operator is NULL", K(ret), KP(kit));
+    } else {
+      ObMaterialOpInput *mat_input = static_cast<ObMaterialOpInput *>(kit->input_);
+      if (bypass) {
+        // only bypass material marked as bypassable
+        mat_input->set_bypass(mat->get_bypassable());
+      } else {
+        mat_input->set_bypass(false);
+      }
+    }
+  } else if (PHY_VEC_MATERIAL == phy_op->get_type()) {
+    const ObMaterialVecSpec *mat = static_cast<const ObMaterialVecSpec *>(phy_op);
+    ObOperatorKit *kit = exec_ctx.get_operator_kit(mat->id_);
+    if (OB_ISNULL(kit) || OB_ISNULL(kit->input_)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("operator is NULL", K(ret), KP(kit));
+    } else {
+      ObMaterialVecOpInput *mat_input = static_cast<ObMaterialVecOpInput *>(kit->input_);
+      if (bypass) {
+        // only bypass material marked as bypassable
+        mat_input->set_bypass(mat->get_bypassable());
+      } else {
+        mat_input->set_bypass(false);
+      }
+    }
+  }
+
+  if (OB_SUCC(ret) && !IS_PX_TRANSMIT(phy_op->get_type())) {
+    for (int64_t i = 0; OB_SUCC(ret) && i < phy_op->get_child_num(); ++i) {
+      const ObOpSpec *child = phy_op->get_child(i);
+      if (OB_FAIL(bypass_material(exec_ctx, child, bypass))) {
+        LOG_WARN("failed to bypass material of child", K(ret));
+      }
+    } // end for
+  }
+
+  return ret;
 }
 
 int ObDfoSchedDepthGenerator::try_set_dfo_unblock(ObExecContext &exec_ctx, ObDfo &dfo)
@@ -175,6 +249,324 @@ int ObDfoSchedDepthGenerator::try_set_dfo_block(ObExecContext &exec_ctx, ObDfo &
         ObMaterialVecOpInput *mat_input = static_cast<ObMaterialVecOpInput *>(kit->input_);
         mat_input->set_bypass(!block); // so that this dfo will have a blocked material op
       }
+    }
+  }
+  return ret;
+}
+
+int64_t ObDfoSchedSimulator::ObFinalCountGetter::operator()(const ObDfo &dfo) const
+{
+  return dfo.get_assigned_worker_count();
+}
+
+int64_t ObDfoSchedSimulator::ObDopCountGetter::operator()(const ObDfo &dfo) const
+{
+  return dfo.get_dop();
+}
+
+int ObDfoSchedSimulator::create(const ObDfoAssignGetter &dfo_assign_getter,
+                                bool collect_maximum_worker)
+{
+  int ret = OB_SUCCESS;
+  if (OB_FAIL(dfo_state_map_.create(dfos_.count(), ObModIds::OB_SQL_PX, ObModIds::OB_SQL_PX))) {
+    LOG_WARN("fail to create hash map", K(ret));
+  } else if (OB_FAIL(dfo_start_ts_map_.create(dfos_.count() << 1, ObModIds::OB_SQL_PX,
+                                              ObModIds::OB_SQL_PX))) {
+    LOG_WARN("fail to create hash map", K(ret));
+  } else if (OB_FAIL(dfo_max_wokrer_cnt_map_.create(dfos_.count(), ObModIds::OB_SQL_PX,
+                                                    ObModIds::OB_SQL_PX))) {
+    LOG_WARN("fail to create hash map", K(ret));
+  } else {
+    inited_ = true;
+    dfo_assign_getter_ = dfo_assign_getter;
+    collect_maximum_worker_ = collect_maximum_worker;
+  }
+
+  return ret;
+}
+
+int ObDfoSchedSimulator::destroy()
+{
+  int ret = OB_SUCCESS;
+  if (OB_FAIL(dfo_state_map_.destroy())) {
+    LOG_WARN("fail to destroy hash map");
+  } else if (OB_FAIL(dfo_start_ts_map_.destroy())) {
+    LOG_WARN("fail to destroy hash map");
+  } else if (OB_FAIL(dfo_max_wokrer_cnt_map_.destroy())) {
+    LOG_WARN("fail to destroy hash map");
+  } else {
+    ts_worker_cnt_map_.destroy();
+  }
+  return ret;
+}
+
+int ObDfoSchedSimulator::get_max_assigned_worker(int64_t &max_assigned) const
+{
+  int ret = OB_SUCCESS;
+  if (!is_inited()) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("dfo scheduling simulator is not inited", K(ret));
+  } else {
+    max_assigned = max_assigned_;
+  }
+  return ret;
+}
+
+int ObDfoSchedSimulator::get_max_concurrent_workers(const ObDfo *dfo,
+                                                    int64_t &max_concurrent_worker) const
+{
+  int ret = OB_SUCCESS;
+  if (!is_inited()) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("dfo scheduling simulator is not inited", K(ret));
+  } else if (OB_FAIL(
+               dfo_max_wokrer_cnt_map_.get_refactored(dfo->get_dfo_id(), max_concurrent_worker))) {
+    LOG_WARN("fail to get hash map", K(ret));
+  }
+  return ret;
+}
+
+int ObDfoSchedSimulator::schedule()
+{
+  int ret = OB_SUCCESS;
+
+  if (!is_inited()) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("dfo scheduling simulator is not inited", K(ret));
+  } else {
+    int64_t assigned = 0;
+    ARRAY_FOREACH_X(dfos_, idx, cnt, OB_SUCC(ret))
+    {
+      if (OB_FAIL(
+            dfo_state_map_.set_refactored(dfos_.at(idx)->get_dfo_id(), ObDfoState::WAIT, 1))) {
+        LOG_WARN("fail to set hash map", K(ret));
+      }
+    }
+
+    ARRAY_FOREACH_X(dfos_, idx, cnt, OB_SUCC(ret))
+    {
+      const ObDfo *child = dfos_.at(idx);
+      const ObDfo *parent = child->parent();
+      // Simulate the scheduling and get the maximum of concurrent worker count
+      // TODO: nested PX is not considered now
+      if (OB_ISNULL(parent) || OB_ISNULL(child)) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("dfo edges expect to have parent", KPC(parent), KPC(child), K(ret));
+      } else if (OB_FAIL(schedule_dfo(child, assigned, max_assigned_))) {
+        LOG_WARN("fail to schedule dfo", K(ret));
+      } else if (OB_FAIL(schedule_dfo(parent, assigned, max_assigned_))) {
+        LOG_WARN("fail to schedule dfo", K(ret));
+      } else if (child->has_depend_sibling()) {
+        // In the extreme scenario, all ancestor and sibling DFOs will be scheduled concurrently
+        if (OB_FAIL(schedule_ancester_dfos(parent, assigned, max_assigned_))) {
+          LOG_WARN("fail to schedule ancester dfos", K(ret));
+        } else if (OB_FAIL(schedule_sibling_dfos(child, assigned, max_assigned_))) {
+          LOG_WARN("fail to schedule sibling dfos", K(ret));
+        }
+      } else if (OB_FAIL(schedule_ancester_dfos(parent, assigned, max_assigned_))) {
+        LOG_WARN("fail to schedule ancester dfos", K(ret));
+      }
+      
+      if (OB_SUCC(ret) && OB_FAIL(finish_dfo(child, assigned))) {
+        LOG_WARN("fail to finish dfo", K(ret));
+      }
+    }
+  }
+  return ret;
+}
+
+int ObDfoSchedSimulator::ready_to_early_sched(const ObDfo *dfo, bool &ready_to_sched)
+{
+  int ret = OB_SUCCESS;
+  const ObIArray<ObDfo *> &child_dfos = dfo->get_child_dfos();
+  const ObOpSpec *op;
+  const ObPxTransmitSpec *exchange_out;
+  ObDfoState child_state;
+
+  dfo->get_root(op);
+  exchange_out = static_cast<const ObPxTransmitSpec *>(op);
+
+  ready_to_sched = true;
+  if (OB_ISNULL(exchange_out)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("root operator of exchange should not be null");
+  } else if (exchange_out->child_finish_for_early_sched_) {
+    ARRAY_FOREACH(child_dfos, idx)
+    {
+      if (OB_ISNULL(child_dfos.at(idx))) {
+        LOG_WARN("unexpected null child dfo", K(ret));
+      } else if (OB_FAIL(
+                   dfo_state_map_.get_refactored(child_dfos.at(idx)->get_dfo_id(), child_state))) {
+        LOG_WARN("fail to get hash map", K(ret));
+      } else if (child_state == ObDfoState::WAIT) {
+        ready_to_sched = false;
+      }
+    }
+  }
+  return ret;
+}
+
+int ObDfoSchedSimulator::all_child_dfo_finish(const ObDfo *dfo, bool &all_finish)
+{
+  int ret = OB_SUCCESS;
+  const ObIArray<ObDfo *> &child_dfos = dfo->get_child_dfos();
+  ObDfoState child_state;
+  all_finish = true;
+  ARRAY_FOREACH(child_dfos, idx)
+  {
+    if (OB_ISNULL(child_dfos.at(idx))) {
+      LOG_WARN("unexpected null child dfo", K(ret));
+    } else if (OB_FAIL(
+                 dfo_state_map_.get_refactored(child_dfos.at(idx)->get_dfo_id(), child_state))) {
+      LOG_WARN("fail to get hash map", K(ret));
+    } else if (child_state != ObDfoState::FINISH) {
+      all_finish = false;
+    }
+  }
+
+  return ret;
+}
+
+int ObDfoSchedSimulator::schedule_dfo(const ObDfo *dfo, int64_t &assigned, int64_t &max_assigned)
+{
+  int ret = OB_SUCCESS;
+  ObDfoState state;
+  if (OB_FAIL(dfo_state_map_.get_refactored(dfo->get_dfo_id(), state))) {
+    // ignore the TOP dfo to match the scheduling of optimizer
+    if (ret == OB_HASH_NOT_EXIST
+        && dfo->get_dfo_id() == ObDfo::MAX_DFO_ID) { // use ObDfo::MAX_DFO_ID instead
+      ret = OB_SUCCESS;
+    } else {
+      LOG_WARN("fail to get hash map", K(dfo->get_dfo_id()), K(ret));
+    }
+  } else if (state == ObDfoState::WAIT) {
+    // current dfo hasn't been scheduled yet, schedule it
+    if (OB_FAIL(dfo_state_map_.set_refactored(dfo->get_dfo_id(), ObDfoState::RUNNING, 1))) {
+      LOG_WARN("fail to set hash map", K(dfo->get_dfo_id()), K(ret));
+    } else {
+      assigned += dfo_assign_getter_(*dfo);
+
+      // when a DFO is scheduled, record its timestamp (currently, ts is the index
+      // when the DFO is inserted into the ts_worker_cnt_map_)
+      if (collect_maximum_worker_) {
+        int64_t start_timestamp = ts_worker_cnt_map_.count();
+        if (OB_FAIL(ts_worker_cnt_map_.push_back(assigned))) {
+          LOG_WARN("fail to record the worker count", K(ret));
+        } else if (OB_FAIL(dfo_start_ts_map_.set_refactored(dfo->get_dfo_id(), start_timestamp))) {
+          LOG_WARN("fail to record the dfo's timestamp", K(ret));
+        }
+      }
+
+      if (assigned > max_assigned) {
+        max_assigned = assigned;
+        LOG_TRACE("update total assigned by sibling dfos", K(dfo->get_dfo_id()),
+                  K(dfo->get_assigned_worker_count()), K(max_assigned));
+      }
+    }
+  }
+  return ret;
+}
+
+int ObDfoSchedSimulator::finish_dfo(const ObDfo *dfo, int64_t &assigned)
+{
+  int ret = OB_SUCCESS;
+  ObDfoState state;
+  if (OB_FAIL(dfo_state_map_.get_refactored(dfo->get_dfo_id(), state))) {
+    LOG_WARN("fail to get hash map", K(ret));
+  } else if (state == ObDfoState::RUNNING) {
+    bool all_child_finish;
+    // if DFO has no child dfos or all child DFOs are finished, stop currentDFO
+    if (OB_FAIL(all_child_dfo_finish(dfo, all_child_finish))) {
+      LOG_WARN("fail to get child states", K(ret));
+    } else if (all_child_finish) {
+      if (OB_FAIL(dfo_state_map_.set_refactored(dfo->get_dfo_id(), ObDfoState::FINISH, 1))) {
+        LOG_WARN("fail to set hash map", K(ret));
+      } else {
+        assigned -= dfo_assign_getter_(*dfo);
+
+        if (collect_maximum_worker_) {
+          int64_t start_timestamp;
+          if (OB_FAIL(dfo_start_ts_map_.get_refactored(dfo->get_dfo_id(), start_timestamp))) {
+            LOG_WARN("fail to get the dfo's timestamp", K(ret));
+          } else {
+            int64_t max_worker_cnt = -1;
+            // the following method is O(n), so the total time complexity
+            // is O(n^2), optimize it iterate [start_timestamp,
+            // current_timestamp] to find the max worker count
+            for (int64_t idx = start_timestamp; idx < ts_worker_cnt_map_.count(); ++idx) {
+              if (ts_worker_cnt_map_.at(idx) > max_worker_cnt) {
+                max_worker_cnt = ts_worker_cnt_map_.at(idx);
+              }
+            }
+
+            if (-1 == max_worker_cnt) {
+              ret = OB_ERR_UNEXPECTED;
+              LOG_WARN("fail to get max worker count for current DFO");
+            } else if (OB_FAIL(dfo_max_wokrer_cnt_map_.set_refactored(dfo->get_dfo_id(),
+                                                                      max_worker_cnt))) {
+              LOG_WARN("fail to set hashmap");
+            }
+          }
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+int ObDfoSchedSimulator::schedule_ancester_dfos(const ObDfo *dfo, int64_t &assigned,
+                                                int64_t &max_assigned)
+{
+  int ret = OB_SUCCESS;
+  // To bypass MATERIAL operators, ancestor DFOs will be scheduled.
+  const ObDfo *cur = dfo;
+  ObDfoState state;
+
+  while (OB_SUCC(ret) && OB_NOT_NULL(cur) && cur->has_parent() &&
+         cur->parent()->is_earlier_sched()) {
+    const ObDfo *parent = cur->parent();
+    bool ready_to_sched = false;
+    if (OB_FAIL(ready_to_early_sched(cur, ready_to_sched))) {
+      LOG_WARN("fail to get if dfo is ready to early schedule");
+    } else if (!ready_to_sched) {
+      // only early schedule when all of the child dfos are scheduled
+      break;
+    } else if (OB_FAIL(schedule_dfo(cur->parent(), assigned, max_assigned))) {
+      LOG_WARN("fail to schedule dfo", K(cur->get_dfo_id()), K(ret));
+    } else {
+      cur = cur->parent();
+    }
+  }
+  return ret;
+}
+
+int ObDfoSchedSimulator::schedule_sibling_dfos(const ObDfo *dfo, int64_t &assigned,
+                                               int64_t &max_assigned)
+{
+  // 局部右深树的场景，depend_sibling 和当前 child dfo 都会被调度
+  /* Why need extra flag has_depend_sibling_? Why not use NULL !=
+   * depend_sibling_? dfo5 (dop=2)
+   *         /      |      \
+   *      dfo1(2) dfo2 (4) dfo4 (1)
+   *                        |
+   *                      dfo3 (2)
+   * Schedule order: (4,3) => (4,5) => (4,5,1) => (4,5,2) => (4,5) => (5).
+   * max_dop = (4,5,2) = 1 + 2 + 4 = 7. Depend sibling: dfo4 -> dfo1 ->
+   * dfo2. Depend sibling is stored as a list. We thought dfo2 is depend
+   * sibling of dfo1, and calculated incorrect max_dop = (1,2,5) = 2 + 4 +
+   * 2 = 8. Actually, dfo1 and dfo2 are depend sibling of dfo4, but dfo2
+   * is not depend sibling of dfo1. So we use has_depend_sibling_ record
+   * whether the dfo is the header of list.
+   */
+  int ret = OB_SUCCESS;
+  const ObDfo *child = dfo;
+  while (OB_NOT_NULL(child->depend_sibling())) {
+    child = child->depend_sibling();
+    // sibling dfo are leaf dfos, so they will end quickly
+    if (OB_FAIL(schedule_dfo(child, assigned, max_assigned))) {
+      LOG_WARN("fail to schedule dfo", K(ret));
+    } else if (OB_FAIL(finish_dfo(child, assigned))) {
+      LOG_WARN("fail to finish dfo", K(ret));
     }
   }
   return ret;
@@ -223,6 +615,7 @@ int ObDfoWorkerAssignment::calc_admited_worker_count(const ObIArray<ObDfo*> &dfo
       const int64_t extra_expected = px_expected - px_minimal;
       px_admited = px_minimal + extra_expected * extra_worker / (query_expected - query_minimal);
     }
+
     LOG_TRACE("calc px worker count", K(query_expected), K(query_minimal), K(query_admited),
                             K(px_expected), K(px_minimal), K(px_admited));
   }
@@ -235,60 +628,27 @@ int ObDfoWorkerAssignment::assign_worker(ObDfoMgr &dfo_mgr,
                                          int64_t admited_worker_count)
 {
   int ret = OB_SUCCESS;
-  /*  算法： */
-  /*  1. 基于优化器给出的 dop，给每个 dfo 分配 worker */
-  /*  2. 理想情况是 dop = worker 数 */
-  /*  3. 但是，如果 worker 数不足，则需要降级。降级策略: 每个 dfo 等比少用 worker */
-  /*  4. 为了确定比例，需要找到同时调度时占用 worker 数最多的一组 dop，以它为基准 */
-  /*     计算比例，才能保证其余 dfo 都能获得足够 worker 数 */
 
-  /*  算法可提升点（TODO）： */
-  /*  考虑 expected_worker_count > admited_worker_count 场景， */
-  /*  本算法中计算出 scale rate < 1 ，于是会导致每个 dfo 会做 dop 降级 */
-  /*  而实际上，可以让部分 dfo 的执行不降级。考虑下面这种场景： */
-  /*  */
-  /*          dfo5 */
-  /*         /   \ */
-  /*       dfo1  dfo4 */
-  /*               \ */
-  /*                dfo3 */
-  /*                 \ */
-  /*                 dfo2 */
-  /*  */
-  /*  假设 dop = 5, 那么 expected_worker_count = 3 * 5 = 15 */
-  /*  */
-  /*  考虑线程不足场景，设 admited_worker_count = 10， */
-  /*  那么，算法最优的情况下，我们可以这样分配： */
-  /*  */
-  /*          dfo5 (3 threads) */
-  /*         /   \ */
-  /*   (3)dfo1  dfo4 (4) */
-  /*               \ */
-  /*                dfo3 (5) */
-  /*                 \ */
-  /*                 dfo2 (5) */
-  /*  */
-  /*  当前的实现，由于 dop 等比降低，降低后的 dop = 5 * 10 / 15 = 3，实际分配结果为： */
-  /*  */
-  /*          dfo5 (3) */
-  /*         /   \ */
-  /*   (3)dfo1  dfo4 (3) */
-  /*               \ */
-  /*                dfo3 (3) */
-  /*                 \ */
-  /*                 dfo2 (3) */
-  /*  */
-  /*  显然，当前实现对 CPU 资源的利用不是最高效的。这部分工作可以留到稍后完善。暂时先这样 */
-
+  /*
+   * Dynamically allocate DOP for each worker.
+   * Based on the most extreme scheduling sequence in the actual scenario,
+   * record the maximum number of concurrent workers that may be scheduled simultaneously for each DFO.
+   * Then, perform downgrading based on that number.
+   */
   const ObIArray<ObDfo *> & dfos = dfo_mgr.get_all_dfos();
-
-  // 基于优化器给出的 dop，给每个 dfo 分配 worker
-  // 实际分配的 worker 数一定不大于 dop，但可能小于 dop 给定值
-  // admited_worker_count在rpc作为worker的场景下，值为0.
+  common::hash::ObHashMap<int64_t, int64_t> dfo_start_ts_map;
+  ObSEArray<int64_t, 16> ts_worker_cnt_map;
+   
   double scale_rate = 1.0;
   bool match_expected = false;
   bool compatible_before_420 = false;
-  if (OB_UNLIKELY(admited_worker_count < 0 || expected_worker_count <= 0 || minimal_worker_count <= 0)) {
+  int64_t total_assigned = 0;
+  if (OB_FAIL(dfo_start_ts_map.create(dfos.count(), ObModIds::OB_SQL_PX,
+                                      ObModIds::OB_SQL_PX))) {
+    LOG_WARN("fail to create hash map", K(ret));
+  } else if (OB_UNLIKELY(admited_worker_count < 0 ||
+                         expected_worker_count <= 0 ||
+                         minimal_worker_count <= 0)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("should have at least one worker",  K(ret), K(admited_worker_count),
                                         K(expected_worker_count), K(minimal_worker_count));
@@ -298,25 +658,49 @@ int ObDfoWorkerAssignment::assign_worker(ObDfoMgr &dfo_mgr,
     // compatible with version before 4.2
     compatible_before_420 = true;
     scale_rate = static_cast<double>(admited_worker_count) / static_cast<double>(expected_worker_count);
-  } else if (0 >= admited_worker_count || minimal_worker_count == admited_worker_count) {
+  } else if (0 >= admited_worker_count ||
+             minimal_worker_count == admited_worker_count) {
     scale_rate = 0.0;
-  } else if (OB_UNLIKELY(minimal_worker_count > admited_worker_count
-                         || minimal_worker_count >= expected_worker_count)) {
+  } else if (OB_UNLIKELY(minimal_worker_count > admited_worker_count ||
+                         minimal_worker_count >= expected_worker_count)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("unexpected params", K(ret), K(minimal_worker_count), K(admited_worker_count), K(expected_worker_count));
   } else {
+    // simulate the schedule and get every worker's max concurrent worker number
     scale_rate = static_cast<double>(admited_worker_count - minimal_worker_count)
                  / static_cast<double>(expected_worker_count - minimal_worker_count);
   }
+
+  ObDfoSchedSimulator dfo_sched_simulator(dfos);
+  if (OB_FAIL(dfo_sched_simulator.create(ObDfoSchedSimulator::ObDopCountGetter(), true))) {
+    LOG_WARN("fail to create dfo schedule simulator");
+  } else if (OB_FAIL(dfo_sched_simulator.schedule())) {
+    LOG_WARN("fail to simulate dfo scheduling");
+  } else if (OB_FAIL(
+                 dfo_sched_simulator.get_max_assigned_worker(total_assigned))) {
+    LOG_WARN("fail to get max assigned worker");
+  }
+
   ARRAY_FOREACH_X(dfos, idx, cnt, OB_SUCC(ret)) {
     ObDfo *child = dfos.at(idx);
     int64_t val = 0;
+    int64_t max_concurrent_worker = 0;
     if (match_expected) {
       val = child->get_dop();
     } else if (compatible_before_420) {
       val = std::max(1L, static_cast<int64_t>(static_cast<double>(child->get_dop()) * scale_rate));
     } else {
-      val = 1L + static_cast<int64_t>(std::max(static_cast<double>(child->get_dop() - 1), 0.0) * scale_rate);
+      if (OB_FAIL(dfo_sched_simulator.get_max_concurrent_workers(child, max_concurrent_worker))) {
+        LOG_WARN("fail to get max concurrent workers for DFO", K(ret), K(child->get_dfo_id())); 
+      } else {
+        if (admited_worker_count >= max_concurrent_worker) {
+          val = child->get_dop(); 
+        } else {
+          val = 1L + static_cast<int64_t>(std::max(static_cast<double>(child->get_dop() - 1), 0.0) * static_cast<double>(admited_worker_count - minimal_worker_count)
+                 / static_cast<double>(max_concurrent_worker - minimal_worker_count));
+        }
+        LOG_TRACE("get max concurrent worker count", K(child->get_dfo_id()), K(max_concurrent_worker), K(admited_worker_count), K(val));
+      }
     }
     child->set_assigned_worker_count(val);
     if (child->is_single() && val > 1) {
@@ -330,7 +714,6 @@ int ObDfoWorkerAssignment::assign_worker(ObDfoMgr &dfo_mgr,
   }
 
   // 因为上面取了 max，所以可能实际 assigned 的会超出 admission 数，这时应该报错
-  int64_t total_assigned = 0;
   if (OB_FAIL(ret)) {
   } else if (OB_FAIL(get_dfos_worker_count(dfos, false, total_assigned))) {
     LOG_WARN("failed to get dfos worker count", K(ret));
@@ -348,56 +731,27 @@ int ObDfoWorkerAssignment::assign_worker(ObDfoMgr &dfo_mgr,
   return ret;
 }
 
-int ObDfoWorkerAssignment::get_dfos_worker_count(const ObIArray<ObDfo*> &dfos,
+int ObDfoWorkerAssignment::get_dfos_worker_count(const ObIArray<ObDfo *> &dfos,
                                                  const bool get_minimal,
-                                                 int64_t &total_assigned)
-{
+                                                 int64_t &total_assigned) {
   int ret = OB_SUCCESS;
-  total_assigned = 0;
-  ARRAY_FOREACH_X(dfos, idx, cnt, OB_SUCC(ret)) {
-    const ObDfo *child  = dfos.at(idx);
-    const ObDfo *parent = child->parent();
-    // 计算当前 dfo 和“孩子们”一起调度时消耗的线程数
-    // 找到 expected worker cnt 值最大的一组
-    if (OB_ISNULL(parent) || OB_ISNULL(child)) {
-      ret = OB_ERR_UNEXPECTED;
-      LOG_WARN("dfo edges expect to have parent", KPC(parent), KPC(child), K(ret));
-    } else {
-      int64_t child_assigned = get_minimal ? 1 : child->get_assigned_worker_count();
-      int64_t parent_assigned = get_minimal ? 1 : parent->get_assigned_worker_count();
-      int64_t assigned = parent_assigned + child_assigned;
-      // 局部右深树的场景，depend_sibling 和当前 child dfo 都会被调度
-      /* Why need extra flag has_depend_sibling_? Why not use NULL != depend_sibling_?
-       *               dfo5 (dop=2)
-       *         /      |      \
-       *      dfo1(2) dfo2 (4) dfo4 (1)
-       *                        |
-       *                      dfo3 (2)
-       * Schedule order: (4,3) => (4,5) => (4,5,1) => (4,5,2) => (4,5) => (5). max_dop = (4,5,2) = 1 + 2 + 4 = 7.
-       * Depend sibling: dfo4 -> dfo1 -> dfo2.
-       * Depend sibling is stored as a list.
-       * We thought dfo2 is depend sibling of dfo1, and calculated incorrect max_dop = (1,2,5) = 2 + 4 + 2 = 8.
-       * Actually, dfo1 and dfo2 are depend sibling of dfo4, but dfo2 is not depend sibling of dfo1.
-       * So we use has_depend_sibling_ record whether the dfo is the header of list.
-      */
-      int64_t max_depend_sibling_assigned_worker = 0;
-      if (child->has_depend_sibling()) {
-        while (NULL != child->depend_sibling()) {
-          child = child->depend_sibling();
-          child_assigned = get_minimal ? 1 : child->get_assigned_worker_count();
-          if (max_depend_sibling_assigned_worker < child_assigned) {
-            max_depend_sibling_assigned_worker = child_assigned;
-          }
-        }
-      }
-      assigned += max_depend_sibling_assigned_worker;
-      if (assigned > total_assigned) {
-        total_assigned = assigned;
-        LOG_TRACE("update total assigned", K(idx), K(get_minimal), K(parent_assigned),
-                K(child_assigned), K(max_depend_sibling_assigned_worker), K(total_assigned));
-      }
-    }
+  ObDfoSchedSimulator dfo_sched_simulator(dfos);
+  if (get_minimal && OB_FAIL(dfo_sched_simulator.create(
+                         ObDfoSchedSimulator::ObMinimalCountGetter(), false))) {
+    LOG_WARN("fail to create dfo schedule simulator");
+  } else if (!get_minimal &&
+             OB_FAIL(dfo_sched_simulator.create(
+                 ObDfoSchedSimulator::ObFinalCountGetter(), false))) {
+    LOG_WARN("fail to create dfo schedule simulator");
+  } else if (OB_FAIL(dfo_sched_simulator.schedule())) {
+    LOG_WARN("fail to simulate dfo scheduling");
+  } else if (OB_FAIL(
+                 dfo_sched_simulator.get_max_assigned_worker(total_assigned))) {
+    LOG_WARN("fail to get max assigned worker");
+  } else if (OB_FAIL(dfo_sched_simulator.destroy())) {
+    LOG_WARN("fail to destroy dfo schedule simulator");
   }
+
   return ret;
 }
 
@@ -426,29 +780,31 @@ int ObDfoMgr::init(ObExecContext &exec_ctx,
   int64_t px_expected = 0;
   int64_t px_minimal = 0;
   int64_t px_admited = 0;
+  int64_t px_max_pipeline_depth =
+    min(static_cast<const ObPxCoordSpec *>(&root_op_spec)->get_pipeline_depth(),
+        GCONF._px_max_pipeline_depth);
   if (inited_) {
     ret = OB_INIT_TWICE;
     LOG_WARN("dfo mgr init twice", K(ret));
-  } else if (OB_FAIL(do_split(exec_ctx, allocator_, &root_op_spec, root_dfo_, dfo_int_gen, px_coord_info))) {
+  } else if (OB_FAIL(do_split(exec_ctx, allocator_, &root_op_spec, root_dfo_, dfo_int_gen,
+                              px_coord_info))) {
     LOG_WARN("fail split ops into dfo", K(ret));
   } else if (OB_ISNULL(root_dfo_)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("NULL dfo unexpected", K(ret));
   } else if (!px_coord_info.rf_dpd_info_.is_empty()
-      && OB_FAIL(px_coord_info.rf_dpd_info_.describe_dependency(root_dfo_))) {
+             && OB_FAIL(px_coord_info.rf_dpd_info_.describe_dependency(root_dfo_))) {
     LOG_WARN("failed to describe rf dependency");
   } else if (OB_FAIL(ObDfoSchedOrderGenerator::generate_sched_order(*this))) {
     LOG_WARN("fail init dfo mgr", K(ret));
-  } else if (OB_FAIL(ObDfoSchedDepthGenerator::generate_sched_depth(exec_ctx, *this))) {
+  } else if (OB_FAIL(ObDfoSchedDepthGenerator::generate_sched_depth(exec_ctx, *this,
+                                                                    px_max_pipeline_depth))) {
     LOG_WARN("fail init dfo mgr", K(ret));
-  } else if (OB_FAIL(ObDfoWorkerAssignment::calc_admited_worker_count(get_all_dfos(),
-                                                                      exec_ctx,
-                                                                      root_op_spec,
-                                                                      px_expected,
-                                                                      px_minimal,
-                                                                      px_admited))) {
+  } else if (OB_FAIL(ObDfoWorkerAssignment::calc_admited_worker_count(
+               get_all_dfos(), exec_ctx, root_op_spec, px_expected, px_minimal, px_admited))) {
     LOG_WARN("fail to calc admited worler count", K(ret));
-  } else if (OB_FAIL(ObDfoWorkerAssignment::assign_worker(*this, px_expected, px_minimal, px_admited))) {
+  } else if (OB_FAIL(ObDfoWorkerAssignment::assign_worker(*this, px_expected, px_minimal,
+                                                                 px_admited))) {
     LOG_WARN("fail assign worker to dfos", K(ret),  K(px_expected), K(px_minimal), K(px_admited));
   } else {
     inited_ = true;
@@ -779,6 +1135,21 @@ int ObDfoMgr::get_ready_dfo(ObDfo *&dfo) const
   return ret;
 }
 
+// schdule child dfo and its parent dfo
+int ObDfoMgr::schedule_child_parent(ObIArray<ObDfo *> &dfos, ObDfo *child) const
+{
+  int ret = OB_SUCCESS;
+  if (OB_FAIL(dfos.push_back(child))) {
+    LOG_WARN("fail to push dfo", K(ret));
+  } else if (NULL == child->parent()) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("parent is NULL, unexpected", K(ret));
+  } else if (OB_FAIL(dfos.push_back(child->parent()))) {
+    LOG_WARN("fail push dfo", K(ret));
+  }
+  return ret;
+}
+
 // 注意区别两种返回状态：
 //   - 如果有 edge 还没有 finish，且不能调度更多 dfo，则返回空集合
 //   - 如果所有 edge 都已经 finish，则返回 ITER_END
@@ -787,7 +1158,6 @@ int ObDfoMgr::get_ready_dfos(ObIArray<ObDfo*> &dfos) const
 {
   int ret = OB_SUCCESS;
   bool all_finish = true;
-  bool got_pair_dfo = false;
   dfos.reset();
 
   LOG_TRACE("ready dfos", K(edges_.count()));
@@ -799,21 +1169,14 @@ int ObDfoMgr::get_ready_dfos(ObIArray<ObDfo*> &dfos) const
       LOG_TRACE("finish dfo", K(*edge));
       continue;
     } else {
-      // edge 没有完成，调度的目标就是促成这条边尽快完成，包括调度起它所依赖的 DFO，即：
-      //  - edge 没有调度起来，立即调度
-      //  - edge 已经调度起来，则看这个 edge 是否依赖其它 dfo 才能完成执行
+      // if the DFO is not scheduled, schedule it immediately
+      // else check if this DFO depends on other DFOs to complete execution
       all_finish = false;
       if (!edge->is_active()) {
-        if (OB_FAIL(dfos.push_back(edge))) {
-          LOG_WARN("fail push dfo", K(ret));
-        } else if (NULL == edge->parent()) {
-          ret = OB_ERR_UNEXPECTED;
-          LOG_WARN("parent is NULL, unexpected", K(ret));
-        } else if (OB_FAIL(dfos.push_back(edge->parent()))) {
-          LOG_WARN("fail push dfo", K(ret));
+        if (OB_FAIL(schedule_child_parent(dfos, edge))) {
+          LOG_WARN("fail to schedule current dfo and its parent", K(ret));
         } else {
           edge->set_active();
-          got_pair_dfo = true;
         }
       } else if (edge->has_depend_sibling()) {
         // 找到 dependence 链条中优先依赖的 dfo，
@@ -829,31 +1192,22 @@ int ObDfoMgr::get_ready_dfos(ObIArray<ObDfo*> &dfos) const
         } else if (sibling_edge->is_active()) {
           // nop, wait for a sibling finish.
           // after then can we shedule next edge
-        } else if (OB_FAIL(dfos.push_back(sibling_edge))) {
-          LOG_WARN("fail push dfo", K(ret));
-        } else if (NULL == sibling_edge->parent()) {
-          ret = OB_ERR_UNEXPECTED;
-          LOG_WARN("parent is NULL, unexpected", K(ret));
-        } else if (OB_FAIL(dfos.push_back(sibling_edge->parent()))) {
-          LOG_WARN("fail push dfo", K(ret));
+        } else if (OB_FAIL(schedule_child_parent(dfos, sibling_edge))) {
+          LOG_WARN("fail to schedule current dfo and its parent", K(ret));
         } else {
           sibling_edge->set_active();
-          got_pair_dfo = true;
           LOG_TRACE("start schedule dfo", K(*sibling_edge), K(*sibling_edge->parent()));
         }
-      }else {
-        // 当前 edge 还没有完成，也没有 sibling edge 需要调度，返回 dfos 空集，继续等待
       }
 
-      // 三层 DFO 调度逻辑
-      // 注意：即使上面有 sibling 被调度起来了，已经调度了 3 个 DFO
-      // 也还是会去尝试调度第 4 个 depend parent dfo
-      if (OB_SUCC(ret) && !got_pair_dfo && GCONF._px_max_pipeline_depth > 2) {
+      // Attempt to schedule the parent's parent DFO earlier. Note that the DFO being scheduled 
+      // earlier may run concurrently with the depend sibling DFOs.
+      if (OB_SUCC(ret) && dfos.empty() && GCONF._px_max_pipeline_depth > 2) {
         ObDfo *parent_edge = edge->parent();
-        if (NULL != parent_edge &&
-            !parent_edge->is_active() &&
-            NULL != parent_edge->parent() &&
+        while (OB_NOT_NULL(parent_edge) &&
+            OB_NOT_NULL(parent_edge->parent()) &&
             parent_edge->parent()->is_earlier_sched()) {
+              
           /* 为了便于描述，考虑如下场景：
            *       parent-parent
            *           |
@@ -864,20 +1218,26 @@ int ObDfoMgr::get_ready_dfos(ObIArray<ObDfo*> &dfos) const
            * 并且，parent 的执行依赖于 parent-parent 也被调度（2+dfo调度优化，hash join 的
            * 结果可以直接输出，无需在上面加 material 算子）
            */
-          if (OB_FAIL(dfos.push_back(parent_edge))) {
-            LOG_WARN("fail push dfo", K(ret));
-          } else if (OB_FAIL(dfos.push_back(parent_edge->parent()))) {
-            LOG_WARN("fail push dfo", K(ret));
+          bool ready_to_sched = false;
+          if (parent_edge->is_active()) {
+            // check if current parent's parent depends on ancester
+            parent_edge = parent_edge->parent();
+            continue;
+          } else if (OB_FAIL(parent_edge->ready_to_earlier_sched(ready_to_sched))) {
+            LOG_WARN("fail to get if parent is ready to be earlier scheduled");
+          } else if (!ready_to_sched) {
+            // do nothing, parent is not ready to be earlier scheduled
+          } else if (OB_FAIL(schedule_child_parent(dfos, parent_edge))) {
+            LOG_WARN("fail to schedule current dfo and its parent", K(ret));
           } else {
             parent_edge->set_active();
-            got_pair_dfo = true;
-            LOG_DEBUG("dfo do earlier scheduling", K(*parent_edge->parent()));
           }
+          break;
         }
       }
 
       // If one of root_edge's child has scheduled, we try to start the root_dfo.
-      if (OB_SUCC(ret) && !got_pair_dfo) {
+      if (OB_SUCC(ret) && dfos.empty()) {
         if (edge->is_active() &&
             !root_edge->is_active() &&
             edge->has_parent() &&
@@ -897,7 +1257,6 @@ int ObDfoMgr::get_ready_dfos(ObIArray<ObDfo*> &dfos) const
             LOG_WARN("Fail to push dfo", K(ret));
           } else {
             root_edge->set_active();
-            got_pair_dfo = true;
             LOG_TRACE("Try to schedule root dfo", KP(root_edge), KP(root_dfo_));
           }
         }

--- a/src/sql/engine/px/ob_dfo_mgr.h
+++ b/src/sql/engine/px/ob_dfo_mgr.h
@@ -14,13 +14,13 @@
 #define __OCEANBASE_SQL_ENGINE_PX_DFO_MGR_H__
 
 #include "lib/container/ob_se_array.h"
+#include "lib/hash/ob_hashmap.h"
 #include "sql/engine/px/ob_dfo.h"
 
 namespace oceanbase
 {
 namespace sql
 {
-
 class ObPxCoordInfo;
 class ObDfoMgr
 {
@@ -64,6 +64,8 @@ private:
   int create_dfo(common::ObIAllocator &allocator,
                  const ObOpSpec *dfo_root_op,
                  ObDfo *&dfo) const;
+
+  inline int schedule_child_parent(ObIArray<ObDfo *> &dfos, ObDfo *child) const;
 protected:
   common::ObIAllocator &allocator_;
   bool inited_;
@@ -84,12 +86,95 @@ private:
 class ObDfoSchedDepthGenerator
 {
 public:
-  static int generate_sched_depth(ObExecContext &ctx, ObDfoMgr &dfo_mgr);
+  static int generate_sched_depth(ObExecContext &ctx, ObDfoMgr &dfo_mgr, const int64_t pipeline_depth);
 private:
-  static int do_generate_sched_depth(ObExecContext &ctx, ObDfoMgr &dfo_mgr, ObDfo &root);
+  static int do_generate_sched_depth(ObExecContext &ctx, ObDfoMgr &dfo_mgr, ObDfo &root, const int64_t pipeline_depth);
   static int try_set_dfo_block(ObExecContext &exec_ctx, ObDfo &dfo, bool block = true);
   static int try_set_dfo_unblock(ObExecContext &exec_ctx, ObDfo &dfo);
-  static bool check_if_need_do_earlier_sched(ObDfo &child);
+  static bool check_if_need_do_earlier_sched(ObDfo &child, const int64_t pipeline_depth);
+  static int bypass_material(ObExecContext &exec_ctx, const ObOpSpec *phy_op, bool bypass);
+};
+
+class ObDfoSchedSimulator
+{
+  enum class ObDfoState
+  {
+    WAIT,
+    BLOCK,
+    RUNNING,
+    FINISH,
+    FAIL
+  };
+  using ObDfoAssignGetter = std::function<int64_t(const ObDfo &)>;
+  using ObDfoStateMap = common::hash::ObHashMap<int64_t, ObDfoState>;
+
+public:
+  ObDfoSchedSimulator(const ObIArray<ObDfo *> &dfos) :
+    dfos_(dfos), dfo_state_map_(), dfo_start_ts_map_(), ts_worker_cnt_map_(), dfo_assign_getter_(),
+    inited_(false), collect_maximum_worker_(false), max_assigned_(0)
+  {}
+
+  ~ObDfoSchedSimulator() = default;
+
+public:
+  int create(const ObDfoAssignGetter &dfo_assign_getter, bool collect_maximum_worker);
+
+  int destroy();
+
+  int schedule();
+
+  int get_max_assigned_worker(int64_t &max_assigned) const;
+
+  int get_max_concurrent_workers(const ObDfo *dfo, int64_t &max_concurrent_worker) const;
+
+public:
+  // different Getter of DFO's worker count
+  struct ObMinimalCountGetter
+  {
+    int64_t operator()(const ObDfo &dfo) const
+    {
+      UNUSED(dfo);
+      return 1;
+    }
+  };
+
+  struct ObFinalCountGetter
+  {
+    int64_t operator()(const ObDfo &dfo) const;
+  };
+
+  struct ObDopCountGetter
+  {
+    int64_t operator()(const ObDfo &dfo) const;
+  };
+
+private:
+  bool is_inited() const
+  {
+    return inited_;
+  }
+  int all_child_dfo_finish(const ObDfo *dfo, bool &all_finish);
+
+  int ready_to_early_sched(const ObDfo *dfo, bool &ready_to_sched);
+
+  int schedule_dfo(const ObDfo *dfo, int64_t &assigned, int64_t &max_assigned);
+
+  int finish_dfo(const ObDfo *dfo, int64_t &assigned);
+
+  int schedule_ancester_dfos(const ObDfo *dfo, int64_t &assigned, int64_t &max_assigned);
+
+  int schedule_sibling_dfos(const ObDfo *dfo, int64_t &assigned, int64_t &max_assigned);
+
+private:
+  const ObIArray<ObDfo *> &dfos_;
+  ObDfoStateMap dfo_state_map_;
+  common::hash::ObHashMap<int64_t, int64_t> dfo_start_ts_map_;
+  common::hash::ObHashMap<int64_t, int64_t> dfo_max_wokrer_cnt_map_;
+  ObSEArray<int64_t, 16> ts_worker_cnt_map_;
+  ObDfoAssignGetter dfo_assign_getter_;
+  bool inited_;
+  bool collect_maximum_worker_;
+  int64_t max_assigned_;
 };
 
 class ObDfoWorkerAssignment

--- a/src/sql/engine/px/ob_px_admission.h
+++ b/src/sql/engine/px/ob_px_admission.h
@@ -41,8 +41,9 @@ public:
   ~ObPxAdmission() = default;
   static int64_t admit(ObSQLSessionInfo &session, ObExecContext &exec_ctx,
                        int64_t wait_time_us, int64_t session_target,
+                       ObHashMap<ObAddr, int64_t> &bypass_worker_map,
                        ObHashMap<ObAddr, int64_t> &worker_map,
-                       int64_t req_cnt, int64_t &admit_cnt);
+                       int64_t bypass_req_cnt, int64_t req_cnt, int64_t &admit_cnt);
   static int enter_query_admission(sql::ObSQLSessionInfo &session,
                                    sql::ObExecContext &exec_ctx,
                                    sql::stmt::StmtType stmt_type,

--- a/src/sql/engine/px/ob_px_coord_op.cpp
+++ b/src/sql/engine/px/ob_px_coord_op.cpp
@@ -64,6 +64,7 @@ OB_DEF_SERIALIZE(ObPxCoordSpec)
   BASE_SER((ObPxCoordSpec, ObPxReceiveSpec));
   LST_DO_CODE(OB_UNIS_ENCODE,
               px_expected_worker_count_,
+              px_pipeline_depth,
               qc_id_,
               batch_op_info_,
               table_locations_);
@@ -81,7 +82,7 @@ OB_DEF_DESERIALIZE(ObPxCoordSpec)
 {
   int ret = OB_SUCCESS;
   BASE_DESER((ObPxCoordSpec, ObPxReceiveSpec));
-  LST_DO_CODE(OB_UNIS_DECODE, px_expected_worker_count_, qc_id_, batch_op_info_);
+  LST_DO_CODE(OB_UNIS_DECODE, px_expected_worker_count_, px_pipeline_depth, qc_id_, batch_op_info_);
   int64_t count = 0;
   OB_UNIS_DECODE(count);
   if (OB_SUCC(ret) && count > 0) {
@@ -111,6 +112,7 @@ OB_DEF_SERIALIZE_SIZE(ObPxCoordSpec)
   BASE_ADD_LEN((ObPxCoordSpec, ObPxReceiveSpec));
   LST_DO_CODE(OB_UNIS_ADD_LEN,
               px_expected_worker_count_,
+              px_pipeline_depth,
               qc_id_,
               batch_op_info_,
               table_locations_);

--- a/src/sql/engine/px/ob_px_coord_op.h
+++ b/src/sql/engine/px/ob_px_coord_op.h
@@ -166,6 +166,7 @@ public:
   ObPxCoordSpec(common::ObIAllocator &alloc, const ObPhyOperatorType type)
   : ObPxReceiveSpec(alloc, type),
     px_expected_worker_count_(0),
+    px_pipeline_depth(2),
     qc_id_(common::OB_INVALID_ID),
     batch_op_info_(),
     table_locations_(alloc)
@@ -180,6 +181,14 @@ public:
   {
     return px_expected_worker_count_;
   }
+  inline void set_pipeline_depth(int64_t c)
+  {
+    px_pipeline_depth = c;
+  }
+  inline int64_t get_pipeline_depth() const
+  {
+    return px_pipeline_depth;
+  }
   inline void set_px_batch_op_info(int64_t id, ObPhyOperatorType type)
   {
     batch_op_info_.op_id_ = id;
@@ -188,6 +197,7 @@ public:
   TableLocationFixedArray &get_table_locations()
   { return table_locations_; }
   int64_t px_expected_worker_count_; // 当前 px 可以分到的线程数上限，用于multi-px 限流场景
+  int64_t px_pipeline_depth; // the max pipeline depth of px (minimum is 2) 
   int64_t qc_id_;
   // px在支持分布式batch rescan时需要感知做rescan的算子id以及算子类型
   // 是1对1的对应关系

--- a/src/sql/engine/px/ob_px_target_mgr.cpp
+++ b/src/sql/engine/px/ob_px_target_mgr.cpp
@@ -350,11 +350,11 @@ int ObPxTargetMgr::reset_leader_statistics(uint64_t tenant_id)
 
 int ObPxTargetMgr::apply_target(uint64_t tenant_id, hash::ObHashMap<ObAddr, int64_t> &worker_map,
                                 int64_t wait_time_us, int64_t session_target, int64_t req_cnt,
-                                int64_t &admit_count, uint64_t &admit_version)
+                                int64_t &admit_count, uint64_t &admit_version, bool bypass_material)
 {
   int ret = OB_SUCCESS;
   GET_TARGET_MONITOR(tenant_id, {
-    if (OB_FAIL(target_monitor->apply_target(worker_map, wait_time_us, session_target, req_cnt, admit_count, admit_version))) {
+    if (OB_FAIL(target_monitor->apply_target(worker_map, wait_time_us, session_target, req_cnt, admit_count, admit_version, bypass_material))) {
       LOG_WARN("apply target failed", K(ret), K(tenant_id), K(session_target), K(req_cnt));
     }
   });

--- a/src/sql/engine/px/ob_px_target_mgr.h
+++ b/src/sql/engine/px/ob_px_target_mgr.h
@@ -125,7 +125,7 @@ public:
   // for px_admission
   int apply_target(uint64_t tenant_id, hash::ObHashMap<ObAddr, int64_t> &worker_map,
                    int64_t wait_time_us, int64_t session_target, int64_t req_cnt,
-                   int64_t &admit_count, uint64_t &admit_version);
+                   int64_t &admit_count, uint64_t &admit_version, bool bypass_material);
   int release_target(uint64_t tenant_id, hash::ObHashMap<ObAddr, int64_t> &worker_map, uint64_t admit_version);
 
   // for virtual_table iter

--- a/src/sql/engine/px/ob_px_tenant_target_monitor.cpp
+++ b/src/sql/engine/px/ob_px_tenant_target_monitor.cpp
@@ -387,7 +387,7 @@ int ObPxTenantTargetMonitor::reset_leader_statistics()
 
 int ObPxTenantTargetMonitor::apply_target(hash::ObHashMap<ObAddr, int64_t> &worker_map,
                               int64_t wait_time_us, int64_t session_target, int64_t req_cnt,
-                              int64_t &admit_count, uint64_t &admit_version)
+                              int64_t &admit_count, uint64_t &admit_version, bool bypass_material)
 {
   int ret = OB_SUCCESS;
   admit_count = 0;
@@ -464,7 +464,8 @@ int ObPxTenantTargetMonitor::apply_target(hash::ObHashMap<ObAddr, int64_t> &work
         admit_version = version;
         parallel_session_count_++;
       } else {
-        need_wait = true;
+        // try again with plan without bypassing material
+        need_wait = !bypass_material;
       }
     }
   }

--- a/src/sql/engine/px/ob_px_tenant_target_monitor.h
+++ b/src/sql/engine/px/ob_px_tenant_target_monitor.h
@@ -139,7 +139,7 @@ public:
   // for px_admission
   int apply_target(hash::ObHashMap<ObAddr, int64_t> &worker_map,
                    int64_t wait_time_us, int64_t session_target, int64_t req_cnt,
-                   int64_t &admit_count, uint64_t &admit_version);
+                   int64_t &admit_count, uint64_t &admit_version, bool bypass_material);
   int release_target(hash::ObHashMap<ObAddr, int64_t> &worker_map, uint64_t version);
 
   // for virtual_table iter

--- a/src/sql/optimizer/ob_log_exchange.h
+++ b/src/sql/optimizer/ob_log_exchange.h
@@ -31,6 +31,9 @@ public:
       dfo_id_(common::OB_INVALID_ID),
       px_id_(common::OB_INVALID_ID),
       expected_worker_count_(0),
+      pipeline_depth_(0),
+      need_early_sched_(false),
+      child_finish_for_early_sched_(false),
       is_remote_(false),
       is_task_order_(false),
       is_merge_sort_(false),
@@ -122,6 +125,12 @@ public:
   bool is_px_single() const { return is_single(); }
   void set_expected_worker_count(int64_t c) { expected_worker_count_ = c; }
   int64_t get_expected_worker_count() const { return expected_worker_count_; }
+  void set_pipeline_depth(int64_t c) { pipeline_depth_ = c; }
+  int64_t get_pipeline_depth() const { return pipeline_depth_; }
+  void set_need_early_sched() { need_early_sched_ = true; }
+  bool need_early_sched() const { return need_early_sched_; }
+  void set_child_finish_for_early_sched() { child_finish_for_early_sched_ = true; };
+  bool child_finish_for_early_sched() const { return child_finish_for_early_sched_; }
   virtual int px_pipe_blocking_pre(ObPxPipeBlockingCtx &ctx) override;
   virtual int px_pipe_blocking_post(ObPxPipeBlockingCtx &ctx) override;
   virtual int allocate_granule_post(AllocGIContext &ctx) override;
@@ -222,6 +231,10 @@ private:
   int64_t dfo_id_; // 在 CG 之前就给 dfo 定下 id
   int64_t px_id_; // 在 CG 之前就给多个 px 的 plan 定下每个 px 的 id
   int64_t expected_worker_count_; // 仅供 QC 节点使用，其余 exchange 节点均为 0
+  int64_t pipeline_depth_; // only valid on QC (default as 0)
+  bool need_early_sched_; // true if the dfo this exchange belongs to could be early scheduled
+  bool child_finish_for_early_sched_; // true if the dfo early schedule iff all its child DFOs are
+                                      // scheduled
 
   bool is_remote_; /* true if the exchange is remote single-server */
   bool is_task_order_; // true if the input data is task order

--- a/src/sql/optimizer/ob_log_material.h
+++ b/src/sql/optimizer/ob_log_material.h
@@ -22,13 +22,17 @@ namespace sql
   class ObLogMaterial : public ObLogicalOperator
   {
   public:
-    ObLogMaterial(ObLogPlan &plan) : ObLogicalOperator(plan)
+    ObLogMaterial(ObLogPlan &plan) : ObLogicalOperator(plan), is_bypassable_(false)
     {}
     virtual ~ObLogMaterial() {}
     virtual int est_cost() override;
     virtual int do_re_est_cost(EstimateCostInfo &param, double &card, double &op_cost, double &cost) override;
-    virtual bool is_block_op() const override { return true; }
+    virtual bool is_block_op() const override { return !get_bypassable(); }
+    // During execution, MATERIAL operators could be bypassed iff is_bypassable is set
+    bool get_bypassable() const { return is_bypassable_; }
+    void set_bypassable(bool bypass) { is_bypassable_ = bypass; }
   private:
+    bool is_bypassable_;
     DISALLOW_COPY_AND_ASSIGN(ObLogMaterial);
   };
 }

--- a/src/sql/optimizer/ob_logical_operator.cpp
+++ b/src/sql/optimizer/ob_logical_operator.cpp
@@ -2997,18 +2997,18 @@ int ObLogicalOperator::find_all_tsc(ObIArray<ObLogicalOperator *> &tsc_ops,
   return ret;
 }
 
-int ObLogicalOperator::allocate_material(const int64_t index)
+int ObLogicalOperator::allocate_material(const int64_t index, bool bypassable)
 {
   int ret = OB_SUCCESS;
   ObLogPlan *plan = NULL;
   ObLogicalOperator *child = NULL;
   ObLogPlan *child_plan = NULL;
-  ObLogicalOperator* mat_op = NULL;
+  ObLogMaterial* mat_op = NULL;
   if (OB_ISNULL(plan = get_plan()) || OB_ISNULL(child = get_child(index)) ||
       OB_ISNULL(child_plan = child->get_plan())) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("get unexpected null", K(ret), K(child), K(plan), K(child_plan));
-  } else if (OB_ISNULL(mat_op = child_plan->get_log_op_factory().allocate(*child_plan, log_op_def::LOG_MATERIAL))) {
+  } else if (OB_ISNULL(mat_op = static_cast<ObLogMaterial*>(child_plan->get_log_op_factory().allocate(*child_plan, log_op_def::LOG_MATERIAL)))) {
     ret = OB_ALLOCATE_MEMORY_FAILED;
     LOG_ERROR("failed to allocate material operator", K(ret));
   } else {
@@ -3016,7 +3016,9 @@ int ObLogicalOperator::allocate_material(const int64_t index)
     child->set_parent(mat_op);
     mat_op->set_parent(this);
     set_child(index, mat_op);
-    if (OB_FAIL(mat_op->compute_property())) {
+
+    if (OB_FALSE_IT(mat_op->set_bypassable(bypassable))) {
+    } else if (OB_SUCC(ret) && OB_FAIL(mat_op->compute_property())) {
       LOG_WARN("failed to compute property");
     } else {
       mat_op->set_op_cost(0.0);
@@ -4092,7 +4094,6 @@ int ObLogicalOperator::px_pipe_blocking_post(ObPxPipeBlockingCtx &ctx)
         if (child_op_ctx->has_dfo_below_) {
           child_dfo_cnt += 1;
           max_dfo_child_idx = max(max_dfo_child_idx, i);
-        } else {
         }
         if (child_op_ctx->in_.is_exch() && !is_block_input(i)) {
           if (child_dfo_cnt > 1 && !is_consume_child_1by1()) {
@@ -4101,7 +4102,7 @@ int ObLogicalOperator::px_pipe_blocking_post(ObPxPipeBlockingCtx &ctx)
                 && !static_cast<ObLogDistinct *>(child)->is_push_down()) {
               static_cast<ObLogDistinct*>(child)->set_block_mode(true);
               LOG_DEBUG("distinct block mode", K(lbt()));
-            } else if (OB_FAIL(allocate_material(i))) {
+            } else if (OB_FAIL(allocate_material(i, false))) {
               LOG_WARN("allocate material failed", K(ret));
             }
           } else if (!got_in_exch) {

--- a/src/sql/optimizer/ob_logical_operator.h
+++ b/src/sql/optimizer/ob_logical_operator.h
@@ -1577,7 +1577,7 @@ public:
   //       or you MAY NEED TO CHANGE EVERY CALLER of this method.
   virtual bool is_table_scan() const { return false; }
 
-  int allocate_material(const int64_t index);
+  int allocate_material(const int64_t index, bool bypassable = false);
 
   // Find the first operator through the child operators recursively
   // Found: return OB_SUCCESS, set %op

--- a/src/sql/optimizer/ob_optimizer_context.h
+++ b/src/sql/optimizer/ob_optimizer_context.h
@@ -217,6 +217,8 @@ ObOptimizerContext(ObSQLSessionInfo *session_info,
     minimal_worker_count_(0),
     expected_worker_map_(),
     minimal_worker_map_(),
+    bypass_material_expected_worker_map_(),
+    bypass_material_minimal_worker_map_(),
     all_exprs_(false),
     model_type_(ObOptEstCost::VECTOR_MODEL),
     px_object_sample_rate_(-1),
@@ -243,7 +245,9 @@ ObOptimizerContext(ObSQLSessionInfo *session_info,
   virtual ~ObOptimizerContext()
   {
     expected_worker_map_.destroy();
+    bypass_material_expected_worker_map_.destroy();
     minimal_worker_map_.destroy();
+    bypass_material_minimal_worker_map_.destroy();
     log_plan_factory_.destroy();
   }
   inline const ObSQLSessionInfo *get_session_info() const { return session_info_; }
@@ -525,10 +529,31 @@ ObOptimizerContext(ObSQLSessionInfo *session_info,
   void set_minimal_worker_count(int64_t c) { minimal_worker_count_ = c; }
   int64_t get_minimal_worker_count() const { return minimal_worker_count_; }
 
+  void set_bypass_material_expected_worker_count(int64_t c) { bypass_material_expected_worker_count_ = c; }
+  int64_t get_bypass_material_expected_worker_count() const { return bypass_material_expected_worker_count_; }
+  void set_bypass_material_minimal_worker_count(int64_t c) { bypass_material_minimal_worker_count_ = c; }
+  int64_t get_bypass_material_minimal_worker_count() const { return bypass_material_minimal_worker_count_; }
+
   common::hash::ObHashMap<ObAddr, int64_t>& get_expected_worker_map() { return expected_worker_map_; }
   common::hash::ObHashMap<ObAddr, int64_t>& get_minimal_worker_map() { return minimal_worker_map_; }
   const common::hash::ObHashMap<ObAddr, int64_t>& get_expected_worker_map() const { return expected_worker_map_; }
   const common::hash::ObHashMap<ObAddr, int64_t>& get_minimal_worker_map() const { return minimal_worker_map_; }
+  common::hash::ObHashMap<ObAddr, int64_t> &get_bypass_material_expected_worker_map()
+  {
+    return bypass_material_expected_worker_map_;
+  }
+  common::hash::ObHashMap<ObAddr, int64_t> &get_bypass_material_minimal_worker_map()
+  {
+    return bypass_material_minimal_worker_map_;
+  }
+  const common::hash::ObHashMap<ObAddr, int64_t> &get_bypass_material_expected_worker_map() const
+  {
+    return bypass_material_expected_worker_map_;
+  }
+  const common::hash::ObHashMap<ObAddr, int64_t> &get_bypass_material_minimal_worker_map() const
+  {
+    return bypass_material_minimal_worker_map_;
+  }
   const ObRawExprUniqueSet &get_all_exprs() const { return all_exprs_; };
   ObRawExprUniqueSet &get_all_exprs() { return all_exprs_; };
   inline void set_cost_model_type(ObOptEstCost::MODEL_TYPE type) { model_type_ = type; }
@@ -657,8 +682,12 @@ private:
   bool is_ps_protocol_;
   int64_t expected_worker_count_;
   int64_t minimal_worker_count_;
+  int64_t bypass_material_expected_worker_count_;
+  int64_t bypass_material_minimal_worker_count_;
   common::hash::ObHashMap<ObAddr, int64_t> expected_worker_map_;
   common::hash::ObHashMap<ObAddr, int64_t> minimal_worker_map_;
+  common::hash::ObHashMap<ObAddr, int64_t> bypass_material_expected_worker_map_;
+  common::hash::ObHashMap<ObAddr, int64_t> bypass_material_minimal_worker_map_;
   ObRawExprUniqueSet all_exprs_;
   ObOptEstCost::MODEL_TYPE model_type_;
   double px_object_sample_rate_;

--- a/src/sql/optimizer/ob_px_resource_analyzer.cpp
+++ b/src/sql/optimizer/ob_px_resource_analyzer.cpp
@@ -14,6 +14,7 @@
 #include "sql/optimizer/ob_px_resource_analyzer.h"
 #include "sql/optimizer/ob_logical_operator.h"
 #include "sql/optimizer/ob_log_exchange.h"
+#include "sql/optimizer/ob_log_material.h"
 #include "sql/optimizer/ob_log_table_scan.h"
 #include "sql/optimizer/ob_log_del_upd.h"
 #include "sql/optimizer/ob_log_join_filter.h"
@@ -33,7 +34,23 @@ public:
   ~SchedOrderGenerator() = default;
   int generate(DfoInfo &root, ObIArray<DfoInfo *> &edges);
 };
-}
+
+// Mark the DFOs that will be earlier scheduled
+class SchedDepthGenerator
+{
+public:
+  SchedDepthGenerator(bool do_bypass) : do_bypass_(do_bypass){};
+  ~SchedDepthGenerator() = default;
+  int generate(DfoInfo &root, ObIArray<DfoInfo *> &edges);
+
+private:
+  int check_if_need_do_earlier_sched(const DfoInfo &child, bool &do_earlier_sched);
+  int has_bypassable_material(const ObLogicalOperator *op, bool &found) const;
+  int has_operator_consume_1by1(const ObLogicalOperator *op, bool &found) const;
+  int set_dfo_need_early_sched(ObLogicalOperator *log_op);
+  bool do_bypass_; // bypass the material
+};
+} // namespace sql
 }
 
 // 后序遍历 dfo tree 即为调度顺序
@@ -64,7 +81,177 @@ int SchedOrderGenerator::generate(
   return ret;
 }
 
+int SchedDepthGenerator::generate(DfoInfo &root, ObIArray<DfoInfo *> &edges)
+{
+  int ret = OB_SUCCESS;
+  for (int64_t i = 0; OB_SUCC(ret) && i < root.get_child_count(); ++i) {
+    DfoInfo *child = NULL;
+    if (OB_FAIL(root.get_child(i, child))) {
+      LOG_WARN("fail get child dfo", K(i), K(root), K(ret));
+    } else if (OB_ISNULL(child)) {
+      ret = OB_ERR_UNEXPECTED;
+    } else if (OB_FAIL(generate(*child, edges))) {
+      LOG_WARN("fail do generate edge", K(*child), K(ret));
+    } else if(do_bypass_) {
+      bool do_earlier_sched = false;
+      if (OB_FAIL(check_if_need_do_earlier_sched(*child, do_earlier_sched))) {
+        LOG_WARN("fail to check if need do earlier schedule");
+      } else if (!do_earlier_sched) {
+        // do nothing
+      } else if (OB_FAIL(set_dfo_need_early_sched(child->get_root_op()))) {
+        LOG_WARN("fail to set dfo early scheduled");
+      } else {
+        /*
+          pipeline        pipeline_pos_
 
+          +------------+
+          |            |
+          |  ancestor  |          2 (earlier scheduled)
+          |            |
+          +------+-----+
+                 ^
+                 |
+                 |
+          +------+-----+
+          |            |
+          |   parent   |          1
+          |            |
+          +------+-----+
+                 ^
+                 |
+                 |
+          +------+-----+
+          |            |
+          |    child   |          0
+          |            |
+          +------------+
+        */
+        if (child->get_pipeline_pos() == 0 && !child->is_leaf_node()) {
+          child->set_pipeline_pos(1);
+        }
+
+        if (root.get_pipeline_pos() == 0) { root.set_pipeline_pos(child->get_pipeline_pos() + 1); }
+
+        LOG_TRACE("earlier schedule", K(root.get_pipeline_pos()),
+                  K(root.get_root_op()->get_op_id()), K(child->get_pipeline_pos()),
+                  K(child->get_root_op()->get_op_id()));
+      }
+    }
+  }
+
+  return ret;
+}
+
+int SchedDepthGenerator::check_if_need_do_earlier_sched(const DfoInfo &child,
+                                                        bool &do_earlier_sched)
+{
+  int ret = OB_SUCCESS;
+  ObLogicalOperator *root_op = child.get_root_op();
+  if (OB_ISNULL(root_op) || log_op_def::LOG_EXCHANGE != root_op->get_type()) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("the root operator of DFO should be exchange");
+  } else if (OB_FAIL(has_bypassable_material(root_op->get_child(ObLogicalOperator::first_child),
+                                             do_earlier_sched))) {
+    LOG_WARN("fail to detect bypassable material");
+  }
+
+  return ret;
+}
+
+int SchedDepthGenerator::has_bypassable_material(const ObLogicalOperator *op, bool &found) const
+{
+  int ret = OB_SUCCESS;
+  if (OB_ISNULL(op)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("operator shouldn't be null");
+  } else if (log_op_def::LOG_EXCHANGE == op->get_type()) {
+    found = false;
+  } else if (log_op_def::LOG_MATERIAL == op->get_type()) {
+    const ObLogMaterial *mat_op = static_cast<const ObLogMaterial *>(op);
+    if (OB_ISNULL(mat_op)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("fail to cast ObLogicalOperator to ObLogMaterial");
+    } else {
+      found = mat_op->get_bypassable();
+    }
+  } else {
+    for (int64_t i = 0; OB_SUCC(ret) && !found && i < op->get_num_of_child(); ++i) {
+      bool tmp_found = false;
+      const ObLogicalOperator *child = op->get_child(i);
+      if (OB_FAIL(has_bypassable_material(child, tmp_found))) {
+        LOG_WARN("failed to process block parent", K(ret));
+      } else if (tmp_found) {
+        if (!op->is_block_input(i)) {
+          found = true;
+        }
+      }
+    } // end for
+  }
+
+  return ret;
+}
+
+int SchedDepthGenerator::has_operator_consume_1by1(const ObLogicalOperator *op, bool &found) const
+{
+  int ret = OB_SUCCESS;
+  const ObLogMaterial *mat_op = NULL;
+  found = false;
+
+  if (OB_ISNULL(op)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("operator shouldn't be null");
+  } else if (log_op_def::LOG_EXCHANGE == op->get_type()) {
+    // reach exchange, we should skip all the operators under exchange(the top
+    // exchang of the dfo)
+  } else if (log_op_def::LOG_MATERIAL == op->get_type()
+             && OB_ISNULL(mat_op = static_cast<const ObLogMaterial *>(op))) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("fail to cast ObLogicalOperator to ObLogMaterial");
+  } else if (OB_NOT_NULL(mat_op) && !mat_op->get_bypassable()) {
+    // if the material is not bypassed, we should skip all the operators under
+    // MATERIAL
+  } else if (op->is_consume_child_1by1()) {
+    // find a operator consume child 1by1, just return
+    found = true;
+  } else {
+    for (int64_t i = 0; OB_SUCC(ret) && !found && i < op->get_num_of_child(); ++i) {
+      bool tmp_found = false;
+      const ObLogicalOperator *child = op->get_child(i);
+      if (OB_FAIL(has_operator_consume_1by1(child, tmp_found))) {
+        LOG_WARN("failed to process block parent", K(ret));
+      } else if (tmp_found) {
+        if (!op->is_block_input(i)) { found = true; }
+      }
+    } // end for
+  }
+
+  return ret;
+}
+
+int SchedDepthGenerator::set_dfo_need_early_sched(ObLogicalOperator *op)
+{
+  int ret = OB_SUCCESS;
+  ObLogExchange *exchange_out = static_cast<ObLogExchange *>(op);
+  if (OB_ISNULL(exchange_out) || !exchange_out->is_producer()) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("root op of dfo should be exchange out");
+  } else {
+    exchange_out->set_need_early_sched();
+    // check if this dfo needs to wait all of its child DFOs finish
+    const ObLogicalOperator *cur = op->get_child(ObLogicalOperator::first_child);
+
+    bool contains_consume1by1 = false;
+    if (OB_ISNULL(cur)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("top operator of a dfo should not be null");
+    } else if (OB_FAIL(has_operator_consume_1by1(cur, contains_consume1by1))) {
+      LOG_WARN("fail to detect operator that consume 1by1");
+    } else if (!contains_consume1by1) {
+      exchange_out->set_child_finish_for_early_sched();
+    }
+  }
+  return ret;
+}
 
 // ===================================================================================
 // ===================================================================================
@@ -143,7 +330,7 @@ int DfoInfo::get_child(int64_t idx, DfoInfo *&child)
 
 
 ObPxResourceAnalyzer::ObPxResourceAnalyzer()
-  : allocator_(CURRENT_CONTEXT->get_malloc_allocator())
+  : allocator_(CURRENT_CONTEXT->get_malloc_allocator()), do_bypass_(false)
 {
   allocator_.set_label("PxResourceAnaly");
 }
@@ -538,7 +725,8 @@ int ObPxResourceAnalyzer::recursive_walk_through_px_tree(PxInfo &px_tree)
     } else if (OB_FAIL(px_tree.rf_dpd_info_.describe_dependency(px_tree.root_dfo_))) {
       LOG_WARN("failed to describe dependency");
     } else if (OB_FAIL(walk_through_dfo_tree(px_tree, px_tree.threads_cnt_, px_tree.group_cnt_,
-                                            px_tree.thread_map_, px_tree.group_map_))) {
+                                             px_tree.pipeline_depth_, px_tree.thread_map_,
+                                             px_tree.group_map_))) {
       LOG_WARN("fail calc px thread group count", K(ret));
     } else {
       int64_t op_id = OB_ISNULL(px_tree.root_op_) ? OB_INVALID_ID : px_tree.root_op_->get_op_id();
@@ -551,6 +739,7 @@ int ObPxResourceAnalyzer::recursive_walk_through_px_tree(PxInfo &px_tree)
     } else {
       // 将当前 px 的 expected 线程数设置到 QC 算子中
       px_tree.root_op_->set_expected_worker_count(px_tree.threads_cnt_);
+      px_tree.root_op_->set_pipeline_depth(px_tree.pipeline_depth_);
     }
     px_tree.inited_ = true;
   }
@@ -562,8 +751,9 @@ int ObPxResourceAnalyzer::recursive_walk_through_px_tree(PxInfo &px_tree)
  * Then for each edge:
  * 1. Schedule this edge if not scheduled.
  * 2. Schedule parent of this edge if not scheduled.
- * 3. Schedule depend siblings of this edge one by one. One by one means finish (i-1)th sibling before schedule i-th sibling.
- * 4. Finish this edge if it is a leaf node or all children are finished.
+ * 3. Schedule ancesters of parent if earlier scheduling is possbile. 
+ * 4. Schedule depend siblings of this edge one by one. One by one means finish (i-1)th sibling before schedule i-th sibling.
+ * 5. Finish this edge if it is a leaf node or all children are finished.
 */
 
 /* This function also generate a ObHashMap<ObAddr, int64_t> max_parallel_thread_map.
@@ -576,6 +766,7 @@ int ObPxResourceAnalyzer::walk_through_dfo_tree(
     PxInfo &px_root,
     int64_t &max_parallel_thread_count,
     int64_t &max_parallel_group_count,
+    int64_t &max_pipeline_depth,
     ObHashMap<ObAddr, int64_t> &max_parallel_thread_map,
     ObHashMap<ObAddr, int64_t> &max_parallel_group_map)
 {
@@ -583,6 +774,7 @@ int ObPxResourceAnalyzer::walk_through_dfo_tree(
   // 模拟调度过程
   ObArray<DfoInfo *> edges;
   SchedOrderGenerator sched_order_gen;
+  SchedDepthGenerator sched_depth_gen(do_bypass_);
   int64_t bucket_size = cal_next_prime(10);
   ObHashMap<ObAddr, int64_t> current_thread_map;
   ObHashMap<ObAddr, int64_t> current_group_map;
@@ -594,6 +786,8 @@ int ObPxResourceAnalyzer::walk_through_dfo_tree(
     LOG_WARN("fail normalize px tree", K(ret));
   } else if (OB_FAIL(sched_order_gen.generate(*px_root.root_dfo_, edges))) {
     LOG_WARN("fail generate sched order", K(ret));
+  } else if (OB_FAIL(sched_depth_gen.generate(*px_root.root_dfo_, edges))) {
+    LOG_WARN("fail generate sched depth", K(ret));
   } else if (OB_FAIL(current_thread_map.create(bucket_size,
                                                ObModIds::OB_SQL_PX,
                                                ObModIds::OB_SQL_PX))){
@@ -621,6 +815,17 @@ int ObPxResourceAnalyzer::walk_through_dfo_tree(
                                                           current_thread_map, current_group_map))) {
       LOG_WARN("schedule parent dfo failed", K(ret));
     } else if (child.has_sibling() && child.depend_sibling_->not_scheduled()) {
+      // In the extreme scenario, all ancestor and sibling DFOs will be scheduled concurrently
+      if (OB_FAIL(schedule_ancester_dfos(child, threads, groups, current_thread_map,
+                                         current_group_map))) {
+        LOG_WARN("fail to schedule ancestor dfos", K(ret));
+      } else if (OB_FAIL(update_max_thead_group_info(
+                   threads, groups, current_thread_map, current_group_map, max_threads, max_groups,
+                   max_parallel_thread_map, max_parallel_group_map))) {
+        LOG_WARN("update max_thead group info failed", K(ret));
+      }
+
+      // schedule all of the sibling DFOs
       DfoInfo *sibling = child.depend_sibling_;
       while (NULL != sibling && OB_SUCC(ret)) {
         if (OB_UNLIKELY(!sibling->is_leaf_node())) {
@@ -641,21 +846,21 @@ int ObPxResourceAnalyzer::walk_through_dfo_tree(
           sibling = sibling->depend_sibling_;
         }
       }
-    } else {
-      if (OB_FAIL(update_max_thead_group_info(threads, groups,
-                    current_thread_map, current_group_map,
-                    max_threads, max_groups,
-                    max_parallel_thread_map, max_parallel_group_map))) {
-        LOG_WARN("update max_thead group info failed", K(ret));
-      }
+    } else if (OB_FAIL(schedule_ancester_dfos(child, threads, groups, current_thread_map,
+                                              current_group_map))) {
+      // current DFO depends on no sibling DFOS
+      LOG_WARN("fail to schedule ancestor dfos");
+    } else if (OB_FAIL(update_max_thead_group_info(
+                 threads, groups, current_thread_map, current_group_map, max_threads, max_groups,
+                 max_parallel_thread_map, max_parallel_group_map))) {
+      LOG_WARN("update max_thead group info failed", K(ret));
     }
-    if (OB_SUCC(ret)) {
-      if (OB_FAIL(finish_dfo(child, threads, groups, current_thread_map,
+    if (OB_SUCC(ret) && OB_FAIL(finish_dfo(child, threads, groups, current_thread_map,
                                         current_group_map))) {
         LOG_WARN("finish sibling failed", K(ret));
-      }
     }
 
+    max_pipeline_depth = max(edges[i]->get_pipeline_pos() + 1, max_pipeline_depth);
 #ifndef NDEBUG
       for (int x = 0; x < edges.count(); ++x) {
         LOG_DEBUG("dump dfo step.finish",
@@ -693,6 +898,33 @@ int ObPxResourceAnalyzer::px_tree_append(ObHashMap<ObAddr, int64_t> &max_paralle
       if (OB_FAIL(max_parallel_count.set_refactored(it->first, dop, is_exist))){
         LOG_WARN("set refactored failed", K(ret), K(it->first), K(dop), K(is_exist));
       }
+    }
+  }
+  return ret;
+}
+
+int ObPxResourceAnalyzer::schedule_ancester_dfos(DfoInfo &child, int64_t &threads, int64_t &groups,
+                                                 ObHashMap<ObAddr, int64_t> &current_thread_map,
+                                                 ObHashMap<ObAddr, int64_t> &current_group_map)
+{
+  int ret = OB_SUCCESS;
+  // schedule earlier ancestor dfos of current DFO's parent
+  DfoInfo *cur = child.parent_;
+  while (OB_SUCC(ret) && OB_NOT_NULL(cur) && cur->has_parent()
+         && cur->parent_->is_earlier_sched()) {
+    // check if the cur needs to wait all of its child to be scheduled first
+    const ObLogExchange *exchange_out = static_cast<const ObLogExchange *>(cur->get_root_op());
+    if (OB_ISNULL(exchange_out)) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("root operator of a dfo should be exchange out");
+    } else if (exchange_out->child_finish_for_early_sched() && !cur->is_all_child_scheduled()) {
+      // only early schedule when all of the child dfos are scheduled
+      break;
+    } else if (OB_FAIL(schedule_dfo(*cur->parent_, threads, groups, current_thread_map,
+                                    current_group_map))) {
+      LOG_WARN("fail to ealier schedule the ancester");
+    } else {
+      cur = cur->parent_;
     }
   }
   return ret;

--- a/src/sql/optimizer/ob_px_resource_analyzer.h
+++ b/src/sql/optimizer/ob_px_resource_analyzer.h
@@ -76,6 +76,7 @@ struct DfoInfo {
     force_bushy_(false),
     root_op_(nullptr),
     has_nested_px_(false),
+    pipeline_pos_(0),
     nested_px_thread_cnt_(0),
     nested_px_group_cnt_(0)
   {}
@@ -88,6 +89,7 @@ struct DfoInfo {
   bool force_bushy_;
   ObLogicalOperator *root_op_;
   bool has_nested_px_;
+  int64_t pipeline_pos_;    // 0 if the DFO isn't earlier scheduled and positive for the postion in the 'bypass chain'
   int64_t nested_px_thread_cnt_;
   int64_t nested_px_group_cnt_;
   ObHashMap<ObAddr, int64_t> nested_px_thread_map_;
@@ -105,7 +107,7 @@ struct DfoInfo {
   }
 
   inline void set_root_op(ObLogicalOperator *root_op) { root_op_ = root_op;}
-  inline ObLogicalOperator *get_root_op() { return root_op_;}
+  inline ObLogicalOperator *get_root_op() const { return root_op_;}
   inline void set_force_bushy(bool flag) { force_bushy_ = flag; }
   inline bool force_bushy() { return force_bushy_; }
   bool has_sibling() const { return nullptr != depend_sibling_; }
@@ -119,11 +121,13 @@ struct DfoInfo {
   inline void set_parent(DfoInfo *p) { parent_ = p; }
   void set_dop(int64_t dop) { dop_ = dop; }
   int64_t get_dop() const { return dop_; }
+  void set_pipeline_pos(int pos) { pipeline_pos_ = pos; }
+  int64_t get_pipeline_pos() const { return pipeline_pos_; }
+  bool is_earlier_sched() const { return 1 < pipeline_pos_; }
   bool not_scheduled() { return DfoStatus::INIT == status_; }
   bool is_scheduling() { return DfoStatus::SCHED == status_; }
   void set_scheduled() { status_ = DfoStatus::SCHED; }
   void set_finished() { status_ = DfoStatus::FINISH; }
-  void set_has_depend_sibling(bool has_depend_sibling) { UNUSED(has_depend_sibling); }
   bool is_finish() const
   {
     return DfoStatus::FINISH == status_;
@@ -139,7 +143,18 @@ struct DfoInfo {
     }
     return f;
   }
-  TO_STRING_KV(K_(status), K_(dop), K_(has_nested_px));
+  bool is_all_child_scheduled() const
+  {
+    bool f = true;
+    for (int64_t i = 0; i < child_dfos_.count(); ++i) {
+      if (true == child_dfos_.at(i)->not_scheduled()) {
+        f = false;
+        break;
+      }
+    }
+    return f;
+  }
+  TO_STRING_KV(K_(status), K_(dop), K_(has_nested_px), K_(pipeline_pos));
 };
 
 struct LogRuntimeFilterDependencyInfo
@@ -159,16 +174,18 @@ class ObLogExchange;
 
 /*
  * 计算逻辑计划需要预约多少组线程才能调度成功
+ * ObPxResourceAnalyzer maybe called multiple times to analyze the same plan tree(with/without bypass
+ * material)
  */
 class ObPxResourceAnalyzer
 {
 public:
 struct PxInfo {
   PxInfo() : inited_(false), root_op_(nullptr), root_dfo_(nullptr), threads_cnt_(0), group_cnt_(0),
-             rf_dpd_info_() {}
+             pipeline_depth_(0),rf_dpd_info_() {}
   PxInfo(ObLogExchange *root_op, DfoInfo *root_dfo)
       : inited_(false), root_op_(root_op), root_dfo_(root_dfo),
-        threads_cnt_(0), group_cnt_(0), rf_dpd_info_()
+        threads_cnt_(0), group_cnt_(0), pipeline_depth_(0), rf_dpd_info_()
   {}
   ~PxInfo() {
     destroy();
@@ -188,6 +205,7 @@ struct PxInfo {
   // count of required threads for scheduling this px.
   int64_t threads_cnt_;
   int64_t group_cnt_;
+  int64_t pipeline_depth_;
   ObHashMap<ObAddr, int64_t> thread_map_;
   ObHashMap<ObAddr, int64_t> group_map_;
   LogRuntimeFilterDependencyInfo rf_dpd_info_;
@@ -196,6 +214,7 @@ struct PxInfo {
 public:
   ObPxResourceAnalyzer();
   ~ObPxResourceAnalyzer() = default;
+  void set_do_bypass() { do_bypass_ = true; }
   int analyze(
       ObLogicalOperator &root_op,
       int64_t &max_parallel_thread_count,
@@ -223,6 +242,7 @@ private:
       PxInfo &px_root,
       int64_t &max_parallel_thread_count,
       int64_t &max_parallel_group_count,
+      int64_t &max_pipeline_depth,
       ObHashMap<ObAddr, int64_t> &max_parallel_thread_map,
       ObHashMap<ObAddr, int64_t> &max_parallel_group_map);
   int create_dfo(DfoInfo *&dfo, int64_t dop);
@@ -261,12 +281,20 @@ int update_max_thead_group_info(
     int64_t &max_groups,
     ObHashMap<ObAddr, int64_t> &max_parallel_thread_map,
     ObHashMap<ObAddr, int64_t> &max_parallel_group_map);
+int schedule_ancester_dfos(
+    DfoInfo &child,
+    int64_t &threads,
+    int64_t &groups,
+    ObHashMap<ObAddr, int64_t> &current_thread_map,
+    ObHashMap<ObAddr, int64_t> &current_group_map);
+
 private:
   void print_px_usage(const ObHashMap<ObAddr, int64_t> &max_map);
 private:
   /* variables */
   common::ObArenaAllocator allocator_;
   ObArray<PxInfo *> px_trees_;
+  bool do_bypass_;
   DISALLOW_COPY_AND_ASSIGN(ObPxResourceAnalyzer);
 };
 
@@ -328,7 +356,6 @@ int DfoTreeNormalizer<T>::normalize(T &root)
       root.child_dfos_.at(i - 1)->set_depend_sibling(root.child_dfos_.at(i));
     }
     inode->set_depend_sibling(root.child_dfos_.at(0));
-    inode->set_has_depend_sibling(true);
 
     // (2) transform
     // 将 inode 节点"荡"到最开始的位置

--- a/src/sql/plan_cache/ob_plan_cache_util.h
+++ b/src/sql/plan_cache/ob_plan_cache_util.h
@@ -540,6 +540,8 @@ struct ObPlanStat
   int64_t delayed_px_querys_;    // px query 被丢回队列重试的次数
   int64_t expected_worker_count_;  // px 预期分配线程数
   int64_t minimal_worker_count_;  // minimal threads required for query
+  int64_t bypass_material_expected_worker_count_;  // px 预期分配线程数
+  int64_t bypass_material_minimal_worker_count_;  // minimal threads required for query
   int64_t outline_version_;
   int64_t outline_id_;
   bool is_last_exec_succ_;        // record whether last execute success
@@ -615,6 +617,9 @@ struct ObPlanStat
   PreCalcExprHandler* pre_cal_expr_handler_; //the handler that pre-calculable expression holds
   AddrMap expected_worker_map_; // px 全局预期分配线程数
   AddrMap minimal_worker_map_;  // global minial threads required for query
+  AddrMap bypass_material_expected_worker_map_; // px threads needed to be allocated(when bypass material)
+  AddrMap bypass_material_minimal_worker_map_;  // global minial threads required for query(when bypass material)
+
   uint64_t plan_hash_value_;
   common::ObString outline_data_;
   common::ObString hints_info_;
@@ -649,6 +654,8 @@ struct ObPlanStat
       delayed_px_querys_(0),
       expected_worker_count_(-1),
       minimal_worker_count_(-1),
+      bypass_material_expected_worker_count_(-1),
+      bypass_material_minimal_worker_count_(-1),
       outline_version_(common::OB_INVALID_VERSION),
       outline_id_(common::OB_INVALID_ID),
       is_last_exec_succ_(true),
@@ -725,6 +732,8 @@ struct ObPlanStat
       delayed_px_querys_(rhs.delayed_px_querys_),
       expected_worker_count_(rhs.expected_worker_count_),
       minimal_worker_count_(rhs.minimal_worker_count_),
+      bypass_material_expected_worker_count_(rhs.bypass_material_expected_worker_count_),
+      bypass_material_minimal_worker_count_(rhs.bypass_material_minimal_worker_count_),
       outline_version_(rhs.outline_version_),
       outline_id_(rhs.outline_id_),
       is_last_exec_succ_(rhs.is_last_exec_succ_),


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase**! 
Please read the [How to Contribute](https://github.com/oceanbase/oceanbase/wiki/how_to_contribute) document **BEFORE** filling this PR.

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description

<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->
close #2080.

This PR analyzes the generation logic of all existing MATERIAL operators, pinpointing those that can be bypassed, and refines the corresponding scheduling and resource estimation logic. The goal is to enable a more stable and controllable scheduling of multiple DFOs, which we refer to as N+ DFO Scheduling. This refined approach is designed to optimize resource utilization and enhance overall system efficiency.

### Solution

<!-- Please clearly and consice descipt the solution. -->
The N+DFO scheduling process involves two stages: the planning phase and the execution phase.

#### Planning Phase
After the DFO (Data Flow Operator) partitioning is completed, the optimizer traverses each DFO to check if there are MATERIAL operators that can be bypassed. Currently, two types of MATERIAL operators are primarily bypassed:

- Introduced due to the 2-DFO scheduling logic. These MATERIAL operators can be directly bypassed, reducing the memory overhead of materialization and enhancing the liquidity of intermediate results during the execution phase.

- Introduced for execution correctness. A MATERIAL is allocated above the SHARED HASH JOIN to block until execution is complete, thereby avoiding deadlocks.

Once the optimizer identifies a DFO that contains a bypassable DFO, it marks the current DFO's parent node for early scheduling. The planning phase defaults to early scheduling for all DFOs that may benefit. Currently, if a DFO meets both conditions 1 and 2, and if condition 1 is met, the parent node of the MATERIAL is an Exchange, we consider the DFO to be bypassable. Compared to the original 2-DFO and multi-DFO scheduling strategies, the N+DFO scheduling will schedule a series of ancestral DFOs in advance, which will stream data consumption and avoid intermediate result materialization.

#### Execution Phase
The execution phase process is similar to the planning phase, with `ObDfoMgr` detecting which DFOs need to be scheduled early. Unlike the planning phase, which defaults to early scheduling for all DFOs, the execution phase is limited by the user configuration item _px_max_pipeline_depth, which takes values in the range [2,5]. The default is 2, meaning no early scheduling is performed. When set to 3, an additional DFO is scheduled early, and so on.

During actual scheduling, the chain of DFOs that have bypassed MATERIAL is correspondingly scheduled early. After scheduling a DFO's parent DFO and sibling DFO, if the current DFO's parent DFO can be bypassed, the ancestral DFOs are scheduled early. Otherwise, the parent DFO will be blocked due to the bypassed MATERIAL operator.

### Experiment
On a machine with specifications 90C-200G, we conducted tests using TPC-DS SF100 to compare the execution times of each query with and without the N+ DFO scheduling strategy enabled(3-DFO means schedule one more DFO than 2-DFO) . For queries that did not generate MATERIAL, the N+ DFO strategy is automatically disabled. For queries that did generate MATERIAL, the impact of the N+ DFO strategy on response time (RT) is as follows:
| query | origin    | 3-DFO    | 4-DFO    | 3-DFO speed up | 4-DFO speed up |
|-------|----------|----------|----------|----------------|----------------|
| 15    | 0.755867 | 0.743533 | 0.733133 | 1.63           | 3.01           |
| 24    | 0.610567 | 0.485567 | 0.491467 | 20.47          | 19.51          |
| 25    | 0.605367 | 0.588600 | 0.597867 | 2.77           | 1.24           |
| 34    | 0.318267 | 0.305767 | 0.306433 | 3.93           | 3.72           |
| 37    | 0.368067 | 0.346300 | 0.360033 | 5.91           | 2.18           |
| 44    | 0.689000 | 0.670700 | 0.677867 | 2.66           | 1.62           |
| 54    | 0.768333 | 0.647533 | 0.647733 | 15.72          | 15.7           |
| 60    | 1.104400 | 1.012667 | 1.017767 | 8.31           | 7.84           |
| 69    | 0.788300 | 0.747700 | 0.763500 | 5.15           | 3.15           |
