### PR TITLE
提高method_opt的表达能力 || Improve the expressive ability of method_opt

### DIFF
--- a/src/pl/sys_package/ob_dbms_stats.cpp
+++ b/src/pl/sys_package/ob_dbms_stats.cpp
@@ -4695,7 +4695,7 @@ int ObDbmsStats::parser_for_all_clause(const ParseNode *for_all_node,
     MethodOptColConf for_all_conf;
     MethodOptSizeConf size_conf;
     ParseNode *first  = NULL;
-    if (OB_UNLIKELY(2 != for_all_node->num_child_) ||
+    if (OB_UNLIKELY(4 != for_all_node->num_child_) ||
         OB_ISNULL(first  = for_all_node->children_[0]) ||
         OB_UNLIKELY(first->type_ != T_INT) ||
         OB_UNLIKELY(first->value_ < 0 || first->value_ > 2)) {
@@ -4718,9 +4718,23 @@ int ObDbmsStats::parser_for_all_clause(const ParseNode *for_all_node,
         }
       }
     }
+
+    ObSEArray<ObString, 4> ignore_cols;
+    if (OB_SUCC(ret) && NULL != for_all_node->children_[2]) {
+      if (OB_FAIL(parse_ignore_clause(for_all_node->children_[2], ignore_cols))) {
+        LOG_WARN("failed to parse ignore clause", K(ret));
+      }
+    }
+
+    if (OB_SUCC(ret) && NULL != for_all_node->children_[3]) {
+      if (OB_FAIL(parser_for_columns_clause(for_all_node->children_[3], column_params, ignore_cols))) {
+        LOG_WARN("failed to parse for columns clause", K(ret));
+      }
+    }
+
     for (int64_t i = 0; OB_SUCC(ret) && i < column_params.count(); ++i) {
       ObColumnStatParam &col_param = column_params.at(i);
-      if (!is_match_column_option(col_param, for_all_conf)) {
+      if (!is_match_column_option(col_param, for_all_conf, ignore_cols)) {
         // do nothing
       } else if (!col_param.is_valid_opt_col()) {
         // do nothing
@@ -4728,6 +4742,7 @@ int ObDbmsStats::parser_for_all_clause(const ParseNode *for_all_node,
         LOG_WARN("failed to compute histogram size", K(ret));
       }
     }
+
   }
   return ret;
 }
@@ -4828,7 +4843,8 @@ int ObDbmsStats::compute_bucket_num(ObColumnStatParam &param,
 }
 
 bool ObDbmsStats::is_match_column_option(ObColumnStatParam &param,
-                                         const MethodOptColConf &for_all_opt)
+                                         const MethodOptColConf &for_all_opt,
+                                         const ObIArray<ObString> &ignore_cols)
 {
   bool is_match = false;
   if (FOR_ALL == for_all_opt) {
@@ -4838,6 +4854,13 @@ bool ObDbmsStats::is_match_column_option(ObColumnStatParam &param,
   } else if (FOR_HIDDEN == for_all_opt && param.is_hidden_column()) {
     is_match = true;
   }
+
+  for (int64_t i = 0; is_match && i < ignore_cols.count(); ++i) {
+    if (0 == ignore_cols.at(i).case_compare(param.column_name_)) {
+      is_match = false;
+    }
+  }
+
   return is_match;
 }
 
@@ -4915,6 +4938,30 @@ int ObDbmsStats::parse_for_columns(const ParseNode *node,
   } else if (OB_FAIL(record_cols.push_back(node->children_[1]->str_value_))) {
     LOG_WARN("failed to push back column", K(ret));
   }
+  return ret;
+}
+
+int ObDbmsStats::parse_ignore_clause(const ParseNode *node, ObIArray<ObString> &ignore_cols) {
+  int ret = OB_SUCCESS;
+
+  if (OB_ISNULL(node) ||
+      OB_UNLIKELY(node->type_ != T_COLUMN_LIST)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("node is invalid", K(ret), K(node));
+  } else {
+    for (int64_t i = 0; OB_SUCC(ret) && i < node->num_child_; ++i) {
+      ParseNode *child = node->children_[i];
+      if (OB_ISNULL(child) ||
+          OB_UNLIKELY(child->type_ != T_COLUMN_REF || child->num_child_ != 3) || 
+          OB_ISNULL(child->children_[2])) {
+        ret = OB_ERR_UNEXPECTED;
+        LOG_WARN("node is invalid", K(ret), K(node));
+      } else if (OB_FAIL(ignore_cols.push_back(child->children_[2]->str_value_))) {
+        LOG_WARN("failed to push back column", K(ret));
+      }
+    } 
+  }  
+
   return ret;
 }
 

--- a/src/pl/sys_package/ob_dbms_stats.h
+++ b/src/pl/sys_package/ob_dbms_stats.h
@@ -378,12 +378,15 @@ public:
                                common::ObIArray<ObString> &cols,
                                common::ObIArray<ObString> &record_cols);
 
+  static int parse_ignore_clause(const ParseNode *node, ObIArray<ObString> &ignore_cols);
+
   static int check_is_valid_col(const ObString &src_str,
                                 const ObIArray<ObColumnStatParam> &column_params,
                                 const common::ObIArray<ObString> &record_cols);
 
   static bool is_match_column_option(ObColumnStatParam &param,
-                                     const MethodOptColConf &for_all_opt);
+                                     const MethodOptColConf &for_all_opt,
+                                     const ObIArray<ObString> &ignore_cols);
 
   static bool is_match_column_option(ObColumnStatParam &param,
                                      const ObIArray<ObString> &for_col_list);

--- a/src/sql/parser/sql_parser_mysql_mode.y
+++ b/src/sql/parser/sql_parser_mysql_mode.y
@@ -516,7 +516,7 @@ END_P SET_VAR DELIMITER
 %type <node> opt_resource_option resource_option_list resource_option
 %type <ival> reference_action
 %type <node> alter_foreign_key_action
-%type <node> analyze_stmt analyze_statistics_clause opt_analyze_for_clause opt_analyze_for_clause_list opt_analyze_for_clause_element opt_analyze_sample_clause sample_option for_all opt_indexed_hiddden opt_size_clause size_clause for_columns for_columns_list for_columns_item column_clause
+%type <node> analyze_stmt analyze_statistics_clause opt_analyze_for_clause opt_analyze_for_clause_list opt_analyze_for_clause_element opt_analyze_sample_clause sample_option for_all opt_indexed_hiddden opt_size_clause size_clause for_columns for_columns_list for_columns_item column_clause ignore_clause customize_clause
 %type <node> optimize_stmt
 %type <node> dump_memory_stmt
 %type <node> create_savepoint_stmt rollback_savepoint_stmt release_savepoint_stmt
@@ -20355,11 +20355,35 @@ for_all
 ;
 
 for_all:
-FOR ALL opt_indexed_hiddden COLUMNS opt_size_clause
+FOR ALL opt_indexed_hiddden COLUMNS opt_size_clause ignore_clause customize_clause
 {
-  malloc_non_terminal_node($$, result->malloc_pool_, T_FOR_ALL, 2,
+  malloc_non_terminal_node($$, result->malloc_pool_, T_FOR_ALL, 4,
                            $3, /*opt_indexed_hiddden*/
-                           $5  /*opt_size_clause*/);
+                           $5, /*opt_size_clause*/
+                           $6, /*ignore_clause*/
+                           $7  /*customize_clause*/);
+}
+;
+
+ignore_clause:
+/*empty*/
+{
+  $$ = NULL;
+}
+| IGNORE column_list
+{
+  merge_nodes($$, result, T_COLUMN_LIST, $2);
+}
+;
+
+customize_clause:
+/*empty*/
+{
+  $$ = NULL;
+}
+| SET for_columns_list %prec LOWER_PARENS
+{
+  merge_nodes($$, result, T_FOR_COLUMNS, $2);
 }
 ;
 


### PR DESCRIPTION
## 需求
收集统计信息时，method_opt用于描述要收集哪些列的统计信息以及收集直方图使用的桶的个数。其默认值为for all columns size auto。
但在实际业务使用中，可能需要配置不收集某些列的统计信息，或者某几列不收集直方图。遇到这种场景，目前method_opt的描述能力需要显示指定所有列的收集方式，例如表中有c1 - c10 10列，如果想配置不收集c3,c4 的统计信息，出c7,c8不收集直方图，则需要声明
method_opt => 'for column c1 size auto, column c2 size auto, column c5 size auto, column c6 size auto, column c7 size 1, column c8 size 1, column c9 size auto, column c10 size auto'
一旦遇到大宽表则修改起来非常麻烦。因此我们希望扩展method_opt的语法，增加指定default的能力和将某些列除外的能力。

## 设计
任务涉及模块：
-  src/pl/sys_package/ob_dbms_stats.cpp
-  src/sql/parser/sql_parser_mysql_mode.y
### 思路
mthod_opt中的for all语句为表的所有列设置统计信息搜集策略，可以扩展for all语法，在此函数增加两种能力：

1. 排除为某些列设置默认策略。
排除为c1, c2列设置统计信息收集策略

```
for all columns size auto ignore c1, c2
```
2. 自定义一些列的统计信息收集策略。
自定义c1和c2列的统计信息收集策略
```
for all columns size auto set c1 size 1, c2 size 1
```
3. 排除为一些列设置默认策略的同时为另外一些列设置策略
排除为c1, c2列设置默认统计信息收集策略，同时自定义c3列的收集策略
```
for all columns size auto ignore c1, c2 set c3 size 2
```

**拓展后for all语法为**：
```
FOR ALL [INDEXED | HIDDEN] COLUMNS [size_clause] [ignore_clause] [customize_clause]

ignore_clause:
column_name |
column_name, ignore_clause

customize_clause:
SET columns

columns:
column_name [size_clause] | 
column_name [size_clause], columns
```

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## need
When collecting statistical information, method_opt is used to describe which columns of statistical information are to be collected and the number of buckets used to collect histograms. Its default value is for all columns size auto.
However, in actual business use, it may be necessary to configure not to collect statistical information of certain columns, or not to collect histograms of certain columns. When encountering this scenario, the current description ability of method_opt needs to specify the collection method of all columns. For example, there are 10 columns from c1 to c10 in the table. If you want to configure not to collect statistical information of c3 and c4, the histograms of c7 and c8 will not be collected. , you need to declare
method_opt => 'for column c1 size auto, column c2 size auto, column c5 size auto, column c6 size auto, column c7 size 1, column c8 size 1, column c9 size auto, column c10 size auto'
Once a large wide table is encountered, it will be very troublesome to modify. Therefore, we hope to extend the syntax of method_opt to add the ability to specify default and exclude certain columns.

## design
The tasks involve modules:
- src/pl/sys_package/ob_dbms_stats.cpp
- src/sql/parser/sql_parser_mysql_mode.y
### Ideas
The for all statement in mthod_opt sets the statistics collection strategy for all columns of the table. The for all syntax can be extended. This function adds two capabilities:

1. Exclude setting the default policy for certain columns.
Exclude setting statistics collection policy for columns c1 and c2

```
for all columns size auto ignore c1, c2
```
2. Customize a series of statistical information collection strategies.
Customize statistics collection strategy for columns c1 and c2
```
for all columns size auto set c1 size 1, c2 size 1
```
3. Exclude setting default policies for some columns while setting policies for other columns
Exclude setting the default statistics collection strategy for columns c1 and c2, and customize the collection strategy for column c3.
```
for all columns size auto ignore c1, c2 set c3 size 2
```

**After expansion, the for all syntax is**:
```
FOR ALL [INDEXED | HIDDEN] COLUMNS [size_clause] [ignore_clause] [customize_clause]

ignore_clause:
column_name |
column_name, ignore_clause

customize_clause:
SET columns

columns:
column_name [size_clause] |
column_name [size_clause], columns
```
