### PR TITLE
Bug Fix: 修复了一些统计信息相关的bug || Bug Fix: Fixed some statistics related bugs

### DIFF
--- a/src/pl/sys_package/ob_dbms_stats.cpp
+++ b/src/pl/sys_package/ob_dbms_stats.cpp
@@ -1227,7 +1227,7 @@ int ObDbmsStats::create_stat_table(ObExecContext &ctx, ParamStore &params, ObObj
       LOG_WARN("dbms_stats with temp table not support", K(ret));
       LOG_USER_ERROR(OB_NOT_SUPPORTED, "dbms_stats with temp table");
     } else if (param.db_name_.empty()) {
-      param.db_name_ = session->get_user_name();
+      param.db_name_ = session->get_database_name();
     }
     if (OB_SUCC(ret)) {
       if (OB_FAIL(ObDbmsStatsExportImport::create_stat_table(ctx, param))) {
@@ -1282,7 +1282,7 @@ int ObDbmsStats::drop_stat_table(ObExecContext &ctx, ParamStore &params, ObObj &
       LOG_WARN("Statistics table must be specified", K(ret));
       LOG_USER_ERROR(OB_ERR_DBMS_STATS_PL, "Statistics table must be specified");
     } else if (param.db_name_.empty()) {
-      param.db_name_ = session->get_user_name();
+      param.db_name_ = session->get_database_name();
     }
     if (OB_SUCC(ret)) {
       if (OB_FAIL(ObDbmsStatsExportImport::drop_stat_table(ctx, param))) {
@@ -4537,21 +4537,21 @@ int ObDbmsStats::parse_set_table_stat_options(ObExecContext &ctx,
     LOG_WARN("failed to get ncachehit", K(ret));
   } else if (!nummicroblks.is_null() && OB_FAIL(nummicroblks.get_number(num_nummicroblks))) {
     LOG_WARN("failed to get ncachehit", K(ret));
-  } else if (OB_FAIL(num_numrows.extract_valid_int64_with_trunc(param.numrows_))) {
+  } else if (!numrows.is_null() && OB_FAIL(num_numrows.extract_valid_int64_with_trunc(param.numrows_))) {
     LOG_WARN("extract_valid_int64_with_trunc failed", K(ret), K(num_numrows));
-  } else if (OB_FAIL(num_numblks.extract_valid_int64_with_trunc(param.numblks_))) {
+  } else if (!numblks.is_null() && OB_FAIL(num_numblks.extract_valid_int64_with_trunc(param.numblks_))) {
     LOG_WARN("extract_valid_int64_with_trunc failed", K(ret), K(num_numblks));
-  } else if (OB_FAIL(num_avgrlen.extract_valid_int64_with_trunc(param.avgrlen_))) {
+  } else if (!avgrlen.is_null() && OB_FAIL(num_avgrlen.extract_valid_int64_with_trunc(param.avgrlen_))) {
     LOG_WARN("extract_valid_int64_with_trunc failed", K(ret), K(num_avgrlen));
-  } else if (OB_FAIL(num_flags.extract_valid_int64_with_trunc(param.flags_))) {
+  } else if (!flags.is_null() && OB_FAIL(num_flags.extract_valid_int64_with_trunc(param.flags_))) {
     LOG_WARN("extract_valid_int64_with_trunc failed", K(ret), K(num_flags));
-  } else if (OB_FAIL(num_cachedblk.extract_valid_int64_with_trunc(param.cachedblk_))) {
+  } else if (!cachedblk.is_null() && OB_FAIL(num_cachedblk.extract_valid_int64_with_trunc(param.cachedblk_))) {
     LOG_WARN("extract_valid_int64_with_trunc failed", K(ret), K(num_cachedblk));
-  } else if (OB_FAIL(num_cachehit.extract_valid_int64_with_trunc(param.cachehit_))) {
+  } else if (!cachehit.is_null() && OB_FAIL(num_cachehit.extract_valid_int64_with_trunc(param.cachehit_))) {
     LOG_WARN("extract_valid_int64_with_trunc failed", K(ret), K(num_cachehit));
-  } else if (OB_FAIL(num_nummacroblks.extract_valid_int64_with_trunc(param.nummacroblks_))) {
+  } else if (!nummacroblks.is_null() && OB_FAIL(num_nummacroblks.extract_valid_int64_with_trunc(param.nummacroblks_))) {
     LOG_WARN("extract_valid_int64_with_trunc failed", K(ret), K(num_nummacroblks));
-  } else if (OB_FAIL(num_nummacroblks.extract_valid_int64_with_trunc(param.nummicroblks_))) {
+  } else if (!nummicroblks.is_null() && OB_FAIL(num_nummacroblks.extract_valid_int64_with_trunc(param.nummicroblks_))) {
     LOG_WARN("extract_valid_int64_with_trunc failed", K(ret), K(nummicroblks));
   } else {/*do nothing*/}
   return ret;
@@ -4597,15 +4597,15 @@ int ObDbmsStats::parse_set_column_stats_options(ObExecContext &ctx,
     LOG_WARN("failed to get no_invalidate", K(ret));
   } else if (!force.is_null() && OB_FAIL(force.get_bool(param.table_param_.force_))) {
     LOG_WARN("failed to get force", K(ret));
-  } else if (OB_FAIL(num_distcnt.extract_valid_int64_with_trunc(param.distcnt_))) {
+  } else if (!distcnt.is_null() && OB_FAIL(num_distcnt.extract_valid_int64_with_trunc(param.distcnt_))) {
     LOG_WARN("extract_valid_int64_with_trunc failed", K(ret), K(num_distcnt));
-  } else if (OB_FAIL(ObDbmsStatsUtils::cast_number_to_double(num_density, param.density_))) {
+  } else if (!density.is_null() && OB_FAIL(ObDbmsStatsUtils::cast_number_to_double(num_density, param.density_))) {
     LOG_WARN("failed to cast number to double" , K(ret), K(num_density));
-  } else if (OB_FAIL(num_nullcnt.extract_valid_int64_with_trunc(param.nullcnt_))) {
+  } else if (!nullcnt.is_null() && OB_FAIL(num_nullcnt.extract_valid_int64_with_trunc(param.nullcnt_))) {
     LOG_WARN("extract_valid_int64_with_trunc failed", K(ret), K(num_nullcnt));
-  } else if (OB_FAIL(num_avgclen.extract_valid_int64_with_trunc(param.avgclen_))) {
+  } else if (!avgclen.is_null() && OB_FAIL(num_avgclen.extract_valid_int64_with_trunc(param.avgclen_))) {
     LOG_WARN("extract_valid_int64_with_trunc failed", K(ret), K(num_avgclen));
-  } else if (OB_FAIL(num_flags.extract_valid_int64_with_trunc(param.flags_))) {
+  } else if (!flags.is_null() && OB_FAIL(num_flags.extract_valid_int64_with_trunc(param.flags_))) {
     LOG_WARN("extract_valid_int64_with_trunc failed", K(ret), K(num_flags));
   } else {/*do nothing*/}
   return ret;
@@ -5556,7 +5556,7 @@ int ObDbmsStats::get_all_table_ids_in_database(ObExecContext &ctx,
   } else {
     stat_param.tenant_id_ = session->get_effective_tenant_id();
     if (owner.is_null()) {
-      stat_param.db_name_ = session->get_user_name();
+      stat_param.db_name_ = session->get_database_name();
     } else if (OB_FAIL(owner.get_string(stat_param.db_name_))) {
       LOG_WARN("failed to get db name", K(ret));
     } else if (OB_FAIL(convert_vaild_ident_name(*stat_param.allocator_,

--- a/src/share/stat/ob_dbms_stats_executor.cpp
+++ b/src/share/stat/ob_dbms_stats_executor.cpp
@@ -968,16 +968,13 @@ int ObDbmsStatsExecutor::do_set_table_stats(const ObSetTableStatParam &param,
   if (OB_ISNULL(table_stat)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("get unexpected error", K(ret), K(table_stat));
-  } else if (param.numrows_ < 0 ||
-             param.avgrlen_ < 0 ||
-             param.nummacroblks_ < 0 ||
-             param.nummicroblks_ < 0) {
+  } else if (param.is_invalid()) {
     ret = OB_ERR_DBMS_STATS_PL;
     LOG_WARN("Invalid or inconsistent input values", K(ret), K(param));
     LOG_USER_ERROR(OB_ERR_DBMS_STATS_PL,"Invalid or inconsistent input values");
   } else {
     //1.set numrows_
-    if (param.numrows_ > 0) {
+    if (param.numrows_ != ObSetTableStatParam::NULLOPT) {
       table_stat->set_row_count(param.numrows_);
     }
     //2.set numblks_
@@ -985,13 +982,13 @@ int ObDbmsStatsExecutor::do_set_table_stats(const ObSetTableStatParam &param,
     //   table_stat->set_macro_block_num(param.numrows_);
     // }
     //3.avgrlen_
-    if (param.avgrlen_ > 0) {
+    if (param.avgrlen_ != ObSetTableStatParam::NULLOPT) {
       table_stat->set_avg_row_size(param.avgrlen_);
     }
-    if (param.nummacroblks_ > 0) {
+    if (param.nummacroblks_ != ObSetTableStatParam::NULLOPT) {
       table_stat->set_macro_block_num(param.nummacroblks_);
     }
-    if (param.nummicroblks_ > 0) {
+    if (param.nummicroblks_ != ObSetTableStatParam::NULLOPT) {
       table_stat->set_micro_block_num(param.nummicroblks_);
     }
     //other options support later.
@@ -1009,28 +1006,25 @@ int ObDbmsStatsExecutor::do_set_column_stats(ObIAllocator &allocator,
   if (OB_ISNULL(column_stat)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("get unexpected null", K(ret), K(column_stat));
-  } else if (param.distcnt_ < 0 ||
-             param.density_ < 0 ||
-             param.nullcnt_ < 0 ||
-             param.avgclen_ < 0) {
+  } else if (param.is_invalid()) {
     ret = OB_ERR_DBMS_STATS_PL;
     LOG_WARN("Invalid or inconsistent input values", K(ret), K(param));
     LOG_USER_ERROR(OB_ERR_DBMS_STATS_PL,"Invalid or inconsistent input values");
   } else {
     //1.set distcnt_
-    if (param.distcnt_ > 0) {
+    if (param.distcnt_ != ObSetColumnStatParam::NULLOPT) {
       column_stat->set_num_distinct(param.distcnt_);
     }
     //2.set density_
-    if (param.density_ > 0) {
+    if (param.density_ != ObSetColumnStatParam::NULLOPT) {
       column_stat->get_histogram().set_density(param.density_);
     }
     //3.nullcnt_
-    if (param.nullcnt_ > 0) {
+    if (param.nullcnt_ != ObSetColumnStatParam::NULLOPT) {
       column_stat->set_num_null(param.nullcnt_);
     }
     //4.avgclen_
-    if (param.avgclen_ > 0) {
+    if (param.avgclen_ != ObSetColumnStatParam::NULLOPT) {
       column_stat->set_avg_len(param.avgclen_);
     }
     //5.set max/val value

--- a/src/share/stat/ob_stat_define.h
+++ b/src/share/stat/ob_stat_define.h
@@ -789,6 +789,25 @@ struct ObHistogramParam
 
 struct ObSetTableStatParam
 {
+
+  ObSetTableStatParam():
+  numrows_(NULLOPT),
+  numblks_(NULLOPT),
+  avgrlen_(NULLOPT),
+  flags_(NULLOPT),
+  cachedblk_(NULLOPT),
+  cachehit_(NULLOPT),
+  nummacroblks_(NULLOPT),
+  nummicroblks_(NULLOPT)
+  {}
+
+  inline bool is_invalid() const {
+    return (numrows_ < 0 && numrows_ != NULLOPT) ||
+            (avgrlen_ < 0 && avgrlen_ != NULLOPT) ||
+            (nummacroblks_ < 0 && nummacroblks_ != NULLOPT) ||
+            (nummicroblks_ < 0 && nummicroblks_ != NULLOPT);
+  }
+
   ObTableStatParam table_param_;
 
   int64_t numrows_;
@@ -799,6 +818,8 @@ struct ObSetTableStatParam
   int64_t cachehit_;
   int64_t nummacroblks_;
   int64_t nummicroblks_;
+
+  static constexpr int64_t NULLOPT = -1;
 
   TO_STRING_KV(K(table_param_),
                K(numrows_),
@@ -815,14 +836,22 @@ struct ObSetColumnStatParam
 {
   ObSetColumnStatParam():
   table_param_(),
-  distcnt_(0),
-  density_(0.0),
-  nullcnt_(0),
+  distcnt_(NULLOPT),
+  density_(NULLOPT),
+  nullcnt_(NULLOPT),
   hist_param_(),
-  avgclen_(0),
-  flags_(0),
+  avgclen_(NULLOPT),
+  flags_(NULLOPT),
   col_meta_()
   {}
+
+  inline bool is_invalid() const {
+    return (distcnt_ < 0 && distcnt_ != NULLOPT) ||
+           (density_ < 0 && density_ != NULLOPT) ||
+           (nullcnt_ < 0 && nullcnt_ != NULLOPT) ||
+           (avgclen_ < 0 && avgclen_ != NULLOPT);
+  }
+
   ObTableStatParam table_param_;
   int64_t distcnt_;
   double density_;
@@ -831,6 +860,7 @@ struct ObSetColumnStatParam
   int64_t avgclen_;
   int64_t flags_;
   common::ObObjMeta col_meta_;
+  static constexpr int64_t NULLOPT = -1;
 
   TO_STRING_KV(K(table_param_),
                K(distcnt_),


### PR DESCRIPTION
# 描述
修复了一些统计信息相关的bug，主要有两个问题：

获取默认数据库名的方法调用有误。
和Oracle dbms_stats的兼容性问题：手动为表/列设置统计信息时，对0值的处理不一致。
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
# describe
Fixed some bugs related to statistical information. There are two main issues:

The method call to obtain the default database name is incorrect.
Compatibility issue with Oracle dbms_stats: When manually setting statistics for a table/column, 0 values ​​are treated inconsistently.
