### PR TITLE
Load-Aware Intermediate DFO Scheduling Strategy

### DIFF
--- a/src/observer/omt/ob_multi_tenant.cpp
+++ b/src/observer/omt/ob_multi_tenant.cpp
@@ -2349,6 +2349,24 @@ int ObMultiTenant::get_tenant_cpu_usage(const uint64_t tenant_id, double &usage)
   return ret;
 }
 
+int ObMultiTenant::get_tenant_cpu_percent(const uint64_t tenant_id, double &percent) const
+{
+  int ret = OB_SUCCESS;
+  ObTenant *tenant = nullptr;
+  percent = 0.;
+  if (!lock_.try_rdlock()) {
+    ret = OB_EAGAIN;
+  } else {
+    if (OB_FAIL(get_tenant_unsafe(tenant_id, tenant))) {
+    } else {
+      percent = tenant->get_cpu_percent() * 100.;
+    }
+    lock_.unlock();
+  }
+
+  return ret;
+}
+
 int ObMultiTenant::get_tenant_worker_time(const uint64_t tenant_id, int64_t &worker_time) const
 {
   int ret = OB_SUCCESS;

--- a/src/observer/omt/ob_multi_tenant.h
+++ b/src/observer/omt/ob_multi_tenant.h
@@ -141,6 +141,7 @@ public:
   inline double get_attenuation_factor() const;
   inline int64_t get_times_of_workers() const;
   int get_tenant_cpu_usage(const uint64_t tenant_id, double &usage) const;
+  int get_tenant_cpu_percent(const uint64_t tenant_id, double &percent) const;
   int get_tenant_worker_time(const uint64_t tenant_id, int64_t &worker_time) const;
   int get_tenant_cpu_time(const uint64_t tenant_id, int64_t &rusage_time) const;
   int get_tenant_cpu(

--- a/src/observer/omt/ob_tenant.cpp
+++ b/src/observer/omt/ob_tenant.cpp
@@ -1935,19 +1935,24 @@ void ObTenant::update_token_usage()
   }
 
   if (OB_NOT_NULL(GCTX.cgroup_ctrl_) && GCTX.cgroup_ctrl_->is_valid()) {
-    //do nothing
-  } else if (duration >= 1000 * 1000 && OB_SUCC(thread_list_lock_.trylock())) {  // every second
+    // for CGROUP, use the delta of real CPU time to estimate the cpu percent
+    int64_t prev_cpu_time = ATOMIC_LOAD(&cpu_time_us_);
+    int64_t cur_cpu_time;
+    if (duration >= 1000 * 1000 && OB_SUCC(GCTX.cgroup_ctrl_->get_cpu_time(id_, cur_cpu_time))) {
+      cpu_percent_ = (cur_cpu_time - prev_cpu_time) / duration / unit_max_cpu_;
+      IGNORE_RETURN ATOMIC_SET(&cpu_time_us_, cur_cpu_time);
+    }
+  } else if (duration >= 1000 * 1000 && OB_SUCC(thread_list_lock_.trylock())) { // every second
     int64_t cpu_time_inc = 0;
     DLIST_FOREACH_REMOVESAFE(thread_list_node_, thread_list_)
     {
       Thread *thread = thread_list_node_->get_data();
       int64_t inc = 0;
-      if (OB_SUCC(thread->get_cpu_time_inc(inc))) {
-        cpu_time_inc += inc;
-      }
+      if (OB_SUCC(thread->get_cpu_time_inc(inc))) { cpu_time_inc += inc; }
     }
     thread_list_lock_.unlock();
     IGNORE_RETURN ATOMIC_FAA(&cpu_time_us_, cpu_time_inc);
+    cpu_percent_ = cpu_time_inc / duration / unit_max_cpu_;
   }
 }
 

--- a/src/observer/omt/ob_tenant.h
+++ b/src/observer/omt/ob_tenant.h
@@ -481,6 +481,7 @@ public:
   OB_INLINE void disable_user_sched() { disable_user_sched_ = true; }
   OB_INLINE bool user_sched_enabled() const { return !disable_user_sched_; }
   OB_INLINE double get_token_usage() const { return token_usage_; }
+  OB_INLINE double get_cpu_percent() const { return cpu_percent_; }
   OB_INLINE int64_t get_worker_time() const { return ATOMIC_LOAD(&worker_us_); }
   OB_INLINE int64_t get_cpu_time() const { return ATOMIC_LOAD(&cpu_time_us_); }
   int64_t get_rusage_time();
@@ -612,6 +613,7 @@ public:
   lib::ObQueryRateLimiter sql_limiter_;
   // idle time between two checkpoints
   int64_t worker_us_;
+  double cpu_percent_; // [0, 1], represents the cpu use percent during last sampling duration
   int64_t cpu_time_us_ CACHE_ALIGNED;
 }; // end of class ObTenant
 

--- a/src/sql/engine/px/ob_dfo_scheduler.cpp
+++ b/src/sql/engine/px/ob_dfo_scheduler.cpp
@@ -812,7 +812,6 @@ int ObParallelDfoScheduler::dispatch_dtl_data_channel_info(ObExecContext &ctx, O
    * 这么做可以尽可能保证 transmit 发数据的时候 receive 端有人已经在监听，
    * 否则可能出现 transmit 发出的数据一段时间内无人接收，DTL 会疯狂重试影响系统性能
    */
-
   if (OB_SUCC(ret)) {
     if (parent.is_prealloc_receive_channel() && !parent.is_scheduled()) {
       // 因为 parent 中可以包含多个 receive 算子，仅仅对于调度时的场景
@@ -826,7 +825,6 @@ int ObParallelDfoScheduler::dispatch_dtl_data_channel_info(ObExecContext &ctx, O
       }
     }
   }
-
   if (OB_SUCC(ret)) {
     if (child.is_prealloc_transmit_channel() && !child.is_scheduled()) {
       if (OB_FAIL(dispatch_transmit_channel_info_via_sqc(ctx, child, parent))) {

--- a/src/sql/engine/px/ob_px_rpc_processor.cpp
+++ b/src/sql/engine/px/ob_px_rpc_processor.cpp
@@ -638,7 +638,8 @@ int ObPxTenantTargetMonitorP::process()
       for (int i = 0; OB_SUCC(ret) && i < arg_.addr_target_array_.count(); i++) {
         ObAddr &server = arg_.addr_target_array_.at(i).addr_;
         int64_t peer_used_inc = arg_.addr_target_array_.at(i).target_;
-        if (OB_FAIL(OB_PX_TARGET_MGR.update_peer_target_used(tenant_id, server, peer_used_inc, leader_version))) {
+        double peer_cpu_usage = arg_.addr_target_array_.at(i).cpu_percent_;
+        if (OB_FAIL(OB_PX_TARGET_MGR.update_peer_target_used(tenant_id, server, peer_used_inc, peer_cpu_usage, leader_version))) {
           LOG_WARN("set thread count failed", K(ret), K(tenant_id), K(server), K(peer_used_inc));
         }
       }

--- a/src/sql/engine/px/ob_px_target_mgr.cpp
+++ b/src/sql/engine/px/ob_px_target_mgr.cpp
@@ -301,13 +301,13 @@ int ObPxTargetMgr::get_version(uint64_t tenant_id, uint64_t &version)
 }
 
 int ObPxTargetMgr::update_peer_target_used(uint64_t tenant_id, const ObAddr &server,
-                                           int64_t peer_used, uint64_t version)
+                                           int64_t peer_used, double cpu_percent, uint64_t version)
 {
   int ret = OB_SUCCESS;
   // return OB_HASH_EXIST instead of replacing the element.
   int flag = 0;
   GET_TARGET_MONITOR(tenant_id, {
-    if (OB_FAIL(target_monitor->update_peer_target_used(server, peer_used, version))) {
+    if (OB_FAIL(target_monitor->update_peer_target_used(server, peer_used, cpu_percent, version))) {
       LOG_WARN("update peer target_used failed", K(ret), K(tenant_id), K(peer_used));
     } else if (server_ != server && OB_FAIL(alive_server_set_.set_refactored(server, flag))) {
       if (OB_HASH_EXIST == ret) {

--- a/src/sql/engine/px/ob_px_target_mgr.h
+++ b/src/sql/engine/px/ob_px_target_mgr.h
@@ -79,7 +79,7 @@ public:
   int operator()(hash::HashMapPair<ObAddr, ServerTargetUsage> &entry)
   {
     int ret = common::OB_SUCCESS;
-    if (OB_FAIL(result_.push_peer_target_usage(entry.first, entry.second.get_peer_used()))) {
+    if (OB_FAIL(result_.push_peer_target_usage(entry.first, entry.second.get_peer_used(), entry.second.get_peer_cpu_usage()))) {
       COMMON_LOG(WARN, "push_back peer_used failed", K(ret));
     }
     return ret;
@@ -118,7 +118,7 @@ public:
   // for rpc
   int is_leader(uint64_t tenant_id,  bool &is_leader);
   int get_version(uint64_t tenant_id, uint64_t &version);
-  int update_peer_target_used(uint64_t tenant_id, const ObAddr &server, int64_t peer_used, uint64_t version);
+  int update_peer_target_used(uint64_t tenant_id, const ObAddr &server, int64_t peer_used, double cpu_percent, uint64_t version);
   int gather_global_target_usage(uint64_t tenant_id, ObPxGlobalResGather &gather);
   int reset_leader_statistics(uint64_t tenant_id);
   

--- a/src/sql/engine/px/ob_px_target_monitor_rpc.cpp
+++ b/src/sql/engine/px/ob_px_target_monitor_rpc.cpp
@@ -18,7 +18,7 @@ namespace oceanbase
 namespace sql
 {
 
-OB_SERIALIZE_MEMBER(ObPxRpcAddrTarget, addr_, target_);
+OB_SERIALIZE_MEMBER(ObPxRpcAddrTarget, addr_, target_, cpu_percent_);
 OB_SERIALIZE_MEMBER(ObPxRpcFetchStatArgs, tenant_id_, follower_version_, addr_target_array_, need_refresh_all_);
 OB_SERIALIZE_MEMBER(ObPxRpcFetchStatResponse, status_, tenant_id_, leader_version_, addr_target_array_);
 

--- a/src/sql/engine/px/ob_px_target_monitor_rpc.h
+++ b/src/sql/engine/px/ob_px_target_monitor_rpc.h
@@ -29,15 +29,17 @@ struct ObPxRpcAddrTarget
 {
   OB_UNIS_VERSION(1);
 public:
-  ObPxRpcAddrTarget() : addr_(), target_() {}
-  ObPxRpcAddrTarget(ObAddr addr, int64_t target) : addr_(addr), target_(target) {}
+  ObPxRpcAddrTarget() : addr_(), target_(), cpu_percent_(0.) {}
+  ObPxRpcAddrTarget(ObAddr addr, int64_t target, double cpu_percent) : addr_(addr), target_(target), cpu_percent_(cpu_percent) {}
+  ObPxRpcAddrTarget(ObAddr addr, int64_t target) : addr_(addr), target_(target), cpu_percent_(-1.) {}
   ObAddr addr_;
   int64_t target_;
+  double cpu_percent_;
   TO_STRING_KV(K_(addr), K_(target));
 };
 
-// The follower reports the usage of the local target to the leader, 
-// and receives the current statistics of the global target usage of the leader
+// The follower reports the usage of the local target and cpu to the leader, 
+// and receives the current statistics of the global target & cpu usage of the leader
 class ObPxRpcFetchStatArgs {
   OB_UNIS_VERSION(1);
 public:
@@ -61,6 +63,15 @@ public:
     int ret = OB_SUCCESS;
     if (OB_FAIL(addr_target_array_.push_back(ObPxRpcAddrTarget(server, local_usage)))) {
       COMMON_LOG(WARN, "push_back addr failed", K(server), K(local_usage));
+    }
+    return ret;
+  }
+
+  int push_local_target_usage(const ObAddr &server, int64_t local_usage, double cpu_percent)
+  {
+    int ret = OB_SUCCESS;
+    if (OB_FAIL(addr_target_array_.push_back(ObPxRpcAddrTarget(server, local_usage, cpu_percent)))) {
+      COMMON_LOG(WARN, "push_back addr failed", K(server), K(local_usage), K(cpu_percent));
     }
     return ret;
   }
@@ -95,11 +106,11 @@ public:
   void set_version(uint64_t version) { leader_version_ = version; }
   uint64_t get_version() { return leader_version_; }
 
-  int push_peer_target_usage(const ObAddr &server, int64_t peer_usage)
+  int push_peer_target_usage(const ObAddr &server, int64_t peer_usage, double cpu_percent)
   {
     int ret = OB_SUCCESS;
-    if (OB_FAIL(addr_target_array_.push_back(ObPxRpcAddrTarget(server, peer_usage)))) {
-      COMMON_LOG(WARN, "push_back addr failed", K(server), K(peer_usage));
+    if (OB_FAIL(addr_target_array_.push_back(ObPxRpcAddrTarget(server, peer_usage, cpu_percent)))) {
+      COMMON_LOG(WARN, "push_back addr failed", K(server), K(peer_usage), K(cpu_percent));
     }
     return ret;
   }

--- a/src/sql/engine/px/ob_px_tenant_target_monitor.cpp
+++ b/src/sql/engine/px/ob_px_tenant_target_monitor.cpp
@@ -31,7 +31,7 @@ using namespace obutil;
 namespace sql
 {
 
-OB_SERIALIZE_MEMBER(ServerTargetUsage, peer_target_used_, local_target_used_, report_target_used_);
+OB_SERIALIZE_MEMBER(ServerTargetUsage, peer_target_used_, local_target_used_, report_target_used_, peer_cpu_usage_);
 
 int ObPxTenantTargetMonitor::init(const uint64_t tenant_id, ObAddr &server)
 {
@@ -124,6 +124,19 @@ int ObPxTenantTargetMonitor::refresh_statistics(bool need_refresh_all)
         LOG_WARN("reset statistics failed", K(ret));
       }
       LOG_INFO("refresh global_target_usage_", K(tenant_id_), K(version_), K(server_), K(need_refresh_all));
+    } 
+    if (OB_SUCC(ret)) {
+      // leader needs to update its cpu percent
+      double cpu_percent;
+      ServerTargetUsage target_usage;
+      if (OB_FAIL(GCTX.omt_->get_tenant_cpu_percent(tenant_id_, cpu_percent))) {
+        LOG_WARN("fail to get cpu percent");
+      } else if (OB_FAIL(global_target_usage_.get_refactored(server_, target_usage))){
+        LOG_WARN("fail to get target usage");
+      } else if(OB_FALSE_IT(target_usage.update_peer_cpu_usage(cpu_percent))){
+      } else if (OB_FAIL(global_target_usage_.set_refactored(server_, target_usage, 1))) {
+        LOG_WARN("fail to set target usage");
+      }
     }
   }
   if (!print_debug_log_ && OB_SUCCESS != OB_E(EventTable::EN_PX_PRINT_TARGET_MONITOR_LOG) OB_SUCCESS) {
@@ -244,16 +257,27 @@ int ObPxTenantTargetMonitor::query_statistics(ObAddr &leader)
   SMART_VAR(ObPxRpcFetchStatResponse, result) {
     need_send_refresh_all_ = false;
     if (!args.need_refresh_all()) {
+      ObAddr self_addr = GCTX.self_addr();
       for (hash::ObHashMap<ObAddr, ServerTargetUsage>::iterator it = global_target_usage_.begin();
           OB_SUCC(ret) && it != global_target_usage_.end(); ++it) {
         auto report_local_used = [&](hash::HashMapPair<ObAddr, ServerTargetUsage> &entry) -> int {
           int ret = OB_SUCCESS;
-          // 和上次汇报相比，本机又消耗了entry 机器几个资源，把这个数目汇报给 leader，leader 会把这个值加到全局统计中。
-          // 为什么是汇报“增量”呢？因为 entry 机器的资源被多台机器使用，任何一个人都拿不到全量数据
+          // only the cpu_percent of the local machine will be reported to leader
+          double cpu_percent = -1.;
           int64_t local_used = entry.second.get_local_used();
-          if (local_used == entry.second.get_report_used()) {
-            // do nothing
-          } else if (OB_FAIL(args.push_local_target_usage(entry.first, local_used - entry.second.get_report_used()))) {
+
+          if (self_addr == entry.first && OB_FAIL(GCTX.omt_->get_tenant_cpu_percent(tenant_id_, cpu_percent))) {
+            LOG_WARN("fail to get the tenant cpu percent");
+          }
+          // 和上次汇报相比，本机又消耗了entry 机器几个资源，把这个数目汇报给 leader，leader
+          // 会把这个值加到全局统计中。 为什么是汇报“增量”呢？因为 entry
+          // 机器的资源被多台机器使用，任何一个人都拿不到全量数据
+          else if (local_used == entry.second.get_report_used()
+                   && (cpu_percent < 0.
+                       || abs(entry.second.get_peer_cpu_usage() - cpu_percent) < 5.)) {
+            // do nothing if the workload of current observer keeps the same
+          } else if (OB_FAIL(args.push_local_target_usage(
+                       entry.first, local_used - entry.second.get_report_used(), cpu_percent))) {
             LOG_WARN("push server and target_usage failed", K(ret));
           } else {
             entry.second.set_report_used(local_used);
@@ -279,7 +303,8 @@ int ObPxTenantTargetMonitor::query_statistics(ObAddr &leader)
       for (int i = 0; OB_SUCC(ret) && i < result.addr_target_array_.count(); i++) {
         ObAddr &server = result.addr_target_array_.at(i).addr_;
         int64_t peer_used_full = result.addr_target_array_.at(i).target_;
-        if (OB_FAIL(update_peer_target_used(server, peer_used_full, UINT64_MAX))) {
+        double peer_cpu_usage = result.addr_target_array_.at(i).cpu_percent_;
+        if (OB_FAIL(update_peer_target_used(server, peer_used_full, peer_cpu_usage, UINT64_MAX))) {
           LOG_WARN("set thread count failed", K(ret), K(server), K(peer_used_full));
         }
       }
@@ -310,21 +335,28 @@ uint64_t ObPxTenantTargetMonitor::get_version()
   return version_;
 }
 
-int ObPxTenantTargetMonitor::update_peer_target_used(const ObAddr &server, int64_t peer_used, uint64_t version)
+int ObPxTenantTargetMonitor::update_peer_target_used(const ObAddr &server, int64_t peer_used, double cpu_percent, uint64_t version)
 {
   int ret = OB_SUCCESS;
   ServerTargetUsage target_usage;
   if (print_debug_log_) {
-    LOG_INFO("update_peer_target_used", K(tenant_id_), K(is_leader()), K(version_), K(server), K(peer_used));
+    LOG_INFO("update_peer_target_used", K(tenant_id_), K(is_leader()), K(version_), K(server), K(peer_used), K(cpu_percent));
   }
   auto update_peer_used = [=](hash::HashMapPair<ObAddr, ServerTargetUsage> &entry) -> void {
     if (is_leader()) {
       entry.second.update_peer_used(peer_used);
+      if (cpu_percent > 0.) {
+        // the observer will only send its current CPU usage. Otherwise, it will send 0
+        entry.second.update_peer_cpu_usage(cpu_percent);
+      }
       if (OB_UNLIKELY(entry.second.get_peer_used() < 0)) {
         LOG_ERROR("peer used negative", K(tenant_id_), K(version_), K(server), K(entry.second), K(peer_used));
       }
     } else {
       entry.second.set_peer_used(peer_used);
+      if (cpu_percent > 0.) {
+        entry.second.set_peer_cpu_usage(cpu_percent);
+      }
     }
   };
   SpinWLockGuard rlock_guard(spin_lock_);
@@ -335,6 +367,9 @@ int ObPxTenantTargetMonitor::update_peer_target_used(const ObAddr &server, int64
     if (ret != OB_HASH_NOT_EXIST) {
     } else {
       target_usage.set_peer_used(peer_used);
+      if (cpu_percent > 0.) {
+        target_usage.update_peer_cpu_usage(cpu_percent);
+      }
       if (OB_FAIL(global_target_usage_.set_refactored(server, target_usage))) {
         LOG_WARN("set refactored failed", K(ret));
         if (OB_HASH_EXIST == ret
@@ -531,6 +566,7 @@ int ObPxTenantTargetMonitor::get_all_target_info(common::ObIArray<ObPxTargetInfo
     monitor_info.peer_target_used_ = entry.second.get_peer_used() + (entry.second.get_local_used() - entry.second.get_report_used());
     monitor_info.local_target_used_ = entry.second.get_local_used();
     monitor_info.local_parallel_session_count_ = parallel_session_count_;
+    monitor_info.peer_cpu_usage_ = entry.second.get_peer_cpu_usage();
     if (OB_FAIL(target_info_array.push_back(monitor_info))) {
       LOG_WARN("target_info_array push_back failed", K(ret), K(monitor_info));
     }

--- a/src/sql/engine/px/ob_px_util.cpp
+++ b/src/sql/engine/px/ob_px_util.cpp
@@ -34,6 +34,8 @@
 #include "share/external_table/ob_external_table_file_mgr.h"
 #include "rpc/obrpc/ob_net_keepalive.h"
 #include "share/external_table/ob_external_table_utils.h"
+#include "sql/engine/px/ob_px_tenant_target_monitor.h"
+#include "sql/engine/px/ob_px_target_mgr.h"
 
 
 using namespace oceanbase::common;
@@ -747,6 +749,70 @@ int ObPXServerAddrUtil::alloc_by_child_distribution(const ObDfo &child, ObDfo &p
   return ret;
 }
 
+int ObPXServerAddrUtil::collect_cpu_usage_info(const uint64_t tenant_id,
+                                               const ObArray<ObAddr> &addrs,
+                                               ObArray<double> &cpu_usages)
+{
+  int ret = OB_SUCCESS;
+  ObArray<ObPxTargetInfo> target_info_array;
+  if (OB_FAIL(OB_PX_TARGET_MGR.get_all_target_info(tenant_id, target_info_array))) {
+    LOG_WARN("fail to get all target_info");
+  } else {
+    // when size(addrs) isn't large, nested loop search is more efficient
+    ARRAY_FOREACH_N(target_info_array, i, _)
+    {
+      ARRAY_FOREACH_N(addrs, j, _)
+      {
+        if (addrs.at(j) != target_info_array.at(i).peer_server_) {
+          continue;
+        } else {
+          // the cpu usage will be lifted to 10% if it's too low
+          double adjusted_cpu_usages = std::max(10., target_info_array.at(i).peer_cpu_usage_);
+          if (OB_FAIL(cpu_usages.push_back(adjusted_cpu_usages))) {
+            LOG_WARN("fail to push into array");
+          } else {
+            LOG_TRACE("cpu usage information of SQC", K(addrs.at(j)), K(adjusted_cpu_usages),
+                      K(target_info_array.at(i).peer_cpu_usage_));
+          }
+          break;
+        }
+      }
+    }
+
+    CK(cpu_usages.count() == addrs.count());
+  }
+
+  return ret;
+}
+
+int ObPXServerAddrUtil::check_load_balance(const ObArray<double> &cpu_usages, bool &do_load_balance)
+{
+  int ret = OB_SUCCESS;
+  if (cpu_usages.empty()) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("cpu usages should not be empty");
+  } else {
+    // do CPU load balance when the standard deviation of cpu usage is too large
+    double mean = 0.0;
+    ARRAY_FOREACH(cpu_usages, idx)
+    {
+      mean += cpu_usages.at(idx);
+    }
+    mean /= cpu_usages.count();
+
+    double stddev = 0.0;
+    ARRAY_FOREACH(cpu_usages, idx)
+    {
+      stddev += std::pow(cpu_usages.at(idx) - mean, 2);
+    }
+    stddev = std::sqrt(stddev / cpu_usages.count());
+
+    do_load_balance = stddev >= 20.0;
+    LOG_TRACE("interm DFO do cpu load balance", K(do_load_balance), K(stddev));
+  }
+  return ret;
+}
+
 int ObPXServerAddrUtil::alloc_by_random_distribution(ObExecContext &exec_ctx,
     const ObDfo &child, ObDfo &parent)
 {
@@ -766,6 +832,12 @@ int ObPXServerAddrUtil::alloc_by_random_distribution(ObExecContext &exec_ctx,
       OZ(locations.push_back(*tablet_node));
     }
   }
+
+  // collect the workload information and tune the schedule strategy with it
+  // do the load balance iff the cpu usages of observers are skewed
+  ObArray<double> cpu_usage;
+  bool do_load_balance = false;
+
   if (OB_FAIL(ret)) {
   } else if (locations.empty()) {
     // a defensive code, if this SQL does not have a location, still alloc by child
@@ -775,6 +847,11 @@ int ObPXServerAddrUtil::alloc_by_random_distribution(ObExecContext &exec_ctx,
     }
   } else if (OB_FAIL(get_location_addrs<DASTabletLocArray>(locations, addrs))) {
     LOG_WARN("fail get location addrs", K(ret));
+  } else if (OB_FAIL(collect_cpu_usage_info(exec_ctx.get_my_session()->get_effective_tenant_id(),
+                                            addrs, cpu_usage))) {
+    LOG_WARN("fail to collect cpu usage info");
+  } else if (OB_FAIL(check_load_balance(cpu_usage, do_load_balance))) {
+    LOG_WARN("fail to collect cpu usage info");
   } else {
     int64_t parallel = parent.get_assigned_worker_count();
     if (0 >= parallel) {
@@ -783,7 +860,9 @@ int ObPXServerAddrUtil::alloc_by_random_distribution(ObExecContext &exec_ctx,
     ObArray<int64_t> sqc_max_task_counts;
     ObArray<int64_t> sqc_part_counts;
     int64_t total_task_count = 0;
-    if (parallel < addrs.count() && OB_FAIL(do_random_dfo_distribution(addrs, parallel, addrs))) {
+ 
+    if (OB_FAIL(ret)) {
+    }else if (parallel < addrs.count() && OB_FAIL(do_random_dfo_distribution(addrs, parallel, addrs))) {
       LOG_WARN("fail to do random dfo distribution", K(ret));
     } else {
       for (int i = 0; i < addrs.count() && OB_SUCC(ret); ++i) {
@@ -792,9 +871,16 @@ int ObPXServerAddrUtil::alloc_by_random_distribution(ObExecContext &exec_ctx,
         }
       }
     }
+
     if (OB_FAIL(ret)) {
-    } else if (OB_FAIL(split_parallel_into_task(parallel, sqc_part_counts, sqc_max_task_counts))) {
+    } else if (!do_load_balance
+               && OB_FAIL(
+                 split_parallel_into_task(parallel, sqc_part_counts, sqc_max_task_counts))) {
       LOG_WARN("fail to split parallel task", K(ret));
+    } else if (do_load_balance
+               && OB_FAIL(split_parallel_into_task_by_cpu_usage(parallel, sqc_part_counts,
+                                                                cpu_usage, sqc_max_task_counts))) {
+      LOG_WARN("fail to split parallel task by cpu usage", K(ret));
     } else {
       CK(sqc_max_task_counts.count() == addrs.count());
       for (int i = 0; i < sqc_max_task_counts.count() && OB_SUCC(ret); ++i) {
@@ -999,7 +1085,7 @@ int ObPXServerAddrUtil::set_dfo_accessed_location(ObExecContext &ctx,
   ObTableID dml_ref_table_id = OB_INVALID_ID;
   ObSEArray<int64_t, 2>base_order;
   // 处理insert op 对应的partition location信息
-  if (OB_FAIL(ret) || OB_ISNULL(dml_op)) {
+  if (OB_ISNULL(dml_op)) {
     // pass
   } else {
     ObDASTableLoc *table_loc = nullptr;
@@ -1320,9 +1406,66 @@ int ObPXServerAddrUtil::reorder_all_partitions(int64_t table_location_key,
  */
 int ObPXServerAddrUtil::split_parallel_into_task(const int64_t parallel,
                                                  const common::ObIArray<int64_t> &sqc_part_count,
-                                                 common::ObIArray<int64_t> &results) {
+                                                 common::ObIArray<int64_t> &results)
+{
+  return split_parallel_into_task_by_weight(
+    parallel, sqc_part_count, results,
+    [&](int64_t idx, int64_t partition, int64_t parallel, const ObPxSqcTaskCountMeta &meta) {
+      UNUSED(idx);
+      return meta.partition_count_ * parallel / partition;
+    });
+}
+
+int ObPXServerAddrUtil::split_parallel_into_task_by_cpu_usage(
+  const int64_t parallel, const common::ObIArray<int64_t> &sqc_part_count,
+  const common::ObIArray<double> &sqc_cpu_usage, common::ObIArray<int64_t> &results)
+{
+  int ret = OB_SUCCESS;
+  // convert the original cpu usage to cpu weight, a.k.a the cpu idle time
+  double normalized_sum = 0.;
+  ARRAY_FOREACH(sqc_cpu_usage, idx)
+  {
+    normalized_sum += 100. - sqc_cpu_usage.at(idx);
+  }
+
+  // normalize the cpu weight
+  common::ObArray<double> cpu_weight;
+  ARRAY_FOREACH_X(sqc_cpu_usage, idx, cnt, OB_SUCC(ret))
+  {
+    double weight = (100. - sqc_cpu_usage.at(idx)) / normalized_sum * 100.;
+    if (OB_FAIL(cpu_weight.push_back(weight))) {
+      LOG_WARN("fail to push into the cpu weight");
+    }
+  }
+
+  if (OB_SUCC(ret)) {
+    if (sqc_cpu_usage.count() != sqc_part_count.count()) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("wrong number of cpu usages");
+    } else if (OB_FAIL(split_parallel_into_task_by_weight(
+                 parallel, sqc_part_count, results,
+                 [](int64_t idx, int64_t partition, int64_t parallel,
+                    const ObPxSqcTaskCountMeta &meta, const common::ObIArray<double> &sqc_weight) {
+                   UNUSED(partition);
+                   UNUSED(meta);
+                   return sqc_weight.at(idx) * parallel / 100.0;
+                 },
+                 cpu_weight))) {
+      LOG_WARN("fail to split parallel into task by cpu usage");
+    }
+  }
+
+  return ret;
+}
+
+template <typename Func, typename... Args>
+int ObPXServerAddrUtil::split_parallel_into_task_by_weight(
+  const int64_t parallel, const common::ObIArray<int64_t> &sqc_part_count,
+  common::ObIArray<int64_t> &results, Func weight_provider, Args &&...args)
+{
   int ret = OB_SUCCESS;
   common::ObArray<ObPxSqcTaskCountMeta> sqc_task_metas;
+
   int64_t total_part_count = 0;
   int64_t total_thread_count = 0;
   int64_t thread_remain = 0;
@@ -1350,10 +1493,8 @@ int ObPXServerAddrUtil::split_parallel_into_task(const int64_t parallel,
     }
   }
   if (OB_SUCC(ret)) {
-    // 为什么需要调整，因为极端情况下可能有的sqc只能拿到不足一个线程；算法必须保证每个sqc至少
-    // 有一个线程。
-    if (OB_FAIL(adjust_sqc_task_count(sqc_task_metas, parallel, total_part_count))) {
-      LOG_WARN("Failed to adjust sqc task count", K(ret));
+    if (OB_FAIL(adjust_sqc_task_count_by_weight(sqc_task_metas, parallel, total_part_count, weight_provider, std::forward<Args>(args)...))) {
+      LOG_WARN("Failed to adjust sqc task count by weight", K(ret));
     }
   }
   if (OB_SUCC(ret)) {
@@ -1364,7 +1505,7 @@ int ObPXServerAddrUtil::split_parallel_into_task(const int64_t parallel,
       meta.time_ = static_cast<double>(meta.partition_count_) / static_cast<double>(meta.thread_count_);
     }
     // 排序，执行时间长的排在前面
-    auto compare_fun_long_time_first = [](ObPxSqcTaskCountMeta a, ObPxSqcTaskCountMeta b) -> bool { return a.time_ > b.time_; };
+    auto compare_fun_long_time_first = [](const ObPxSqcTaskCountMeta& a, const ObPxSqcTaskCountMeta& b) -> bool { return a.time_ > b.time_; };
     lib::ob_sort(sqc_task_metas.begin(),
               sqc_task_metas.end(),
               compare_fun_long_time_first);
@@ -1402,19 +1543,23 @@ int ObPXServerAddrUtil::split_parallel_into_task(const int64_t parallel,
   return ret;
 }
 
-int ObPXServerAddrUtil::adjust_sqc_task_count(common::ObIArray<ObPxSqcTaskCountMeta> &sqc_tasks,
-                                              int64_t parallel,
-                                              int64_t partition)
+template <typename Func, typename... Args>
+int ObPXServerAddrUtil::adjust_sqc_task_count_by_weight(
+  common::ObIArray<ObPxSqcTaskCountMeta> &sqc_tasks, int64_t parallel, int64_t partition,
+  Func weight_provider, Args &&...args)
 {
   int ret = OB_SUCCESS;
   int64_t thread_used = 0;
+  UNUSED(partition);
+
   int64_t partition_remain = partition;
   // 存在partition总数为0 的情况，例如，在gi任务划分中，所有partition都没有宏块的情况。
   int64_t real_partition = NON_ZERO_VALUE(partition);
-  ARRAY_FOREACH(sqc_tasks, idx) {
+  ARRAY_FOREACH(sqc_tasks, idx)
+  {
     ObPxSqcTaskCountMeta &meta = sqc_tasks.at(idx);
     if (!meta.finish_) {
-      meta.thread_count_ = meta.partition_count_ * parallel / real_partition;
+      meta.thread_count_ = weight_provider(idx, real_partition, parallel, meta, std::forward<Args>(args)...);
       if (0 >= meta.thread_count_) {
         // 出现小数个线程或者负数个线程，调整改线程为1，标记为finish，后续不再调整它。
         thread_used++;
@@ -1425,10 +1570,12 @@ int ObPXServerAddrUtil::adjust_sqc_task_count(common::ObIArray<ObPxSqcTaskCountM
     }
   }
   if (thread_used != 0) {
-    if (OB_FAIL(adjust_sqc_task_count(sqc_tasks, parallel - thread_used, partition_remain))) {
+    if (OB_FAIL(adjust_sqc_task_count_by_weight(sqc_tasks, parallel - thread_used, partition_remain,
+                                                weight_provider, std::forward<Args>(args)...))) {
       LOG_WARN("Failed to adjust sqc task count", K(ret), K(sqc_tasks));
     }
   }
+
   return ret;
 }
 

--- a/src/sql/engine/px/ob_px_util.h
+++ b/src/sql/engine/px/ob_px_util.h
@@ -159,9 +159,13 @@ public:
   static int split_parallel_into_task(const int64_t parallelism,
                                       const common::ObIArray<int64_t> &sqc_partition_count,
                                       common::ObIArray<int64_t> &results);
-  static int build_tablet_idx_map(
-      const share::schema::ObTableSchema *table_schema,
-      ObTabletIdxMap &idx_map);
+  
+  static int split_parallel_into_task_by_cpu_usage(const int64_t parallelism,
+                                      const common::ObIArray<int64_t> &sqc_partition_count,
+                                      const common::ObIArray<double> &cpu_usage,
+                                      common::ObIArray<int64_t> &results);
+  static int build_tablet_idx_map(const share::schema::ObTableSchema *table_schema,
+                                  ObTabletIdxMap &idx_map);
   static int find_dml_ops(common::ObIArray<const ObTableModifySpec *> &insert_ops,
                           const ObOpSpec &op);
   static int get_external_table_loc(
@@ -244,10 +248,9 @@ private:
     const ObOpSpec *phy_op,
     bool &asc_order);
 
-
-  static int adjust_sqc_task_count(common::ObIArray<ObPxSqcTaskCountMeta> &sqc_tasks,
-                                   int64_t parallel,
-                                   int64_t partition);
+  static int adjust_sqc_task_count_by_cpu_usage(common::ObIArray<ObPxSqcTaskCountMeta> &sqc_tasks,
+                                         const common::ObIArray<double> &sqc_weight, int64_t parallel,
+                                         int64_t partition);
   static int do_random_dfo_distribution(const common::ObIArray<common::ObAddr> &src_addrs,
                                         int64_t dst_addrs_count,
                                         common::ObIArray<common::ObAddr> &dst_addrs);
@@ -258,6 +261,21 @@ private:
                                           common::ObIArray<ObPxSqcMeta *> &sqcs);
 private:
   static int generate_dh_map_info(ObDfo &dfo);
+
+  // allocate the sqc task count based on the weights provided by the weight_provider
+  template <typename Func, typename... Args>
+  static int adjust_sqc_task_count_by_weight(common::ObIArray<ObPxSqcTaskCountMeta> &sqc_tasks,
+                                             int64_t parallel, int64_t partition,
+                                             Func weight_provider, Args &&...args);
+
+  // splits the parallism based on provided weights
+  template <typename Func, typename... Args>
+  static int split_parallel_into_task_by_weight(
+    const int64_t parallelism, const common::ObIArray<int64_t> &sqc_partition_count,
+    common::ObIArray<int64_t> &results, Func weight_provider, Args &&...args);
+  static int collect_cpu_usage_info(const uint64_t tenant_id, const ObArray<ObAddr> &addrs,
+                                    ObArray<double> &cpu_usage);
+  static int check_load_balance(const ObArray<double> &cpu_usage, bool &do_load_balance);
   DISALLOW_COPY_AND_ASSIGN(ObPXServerAddrUtil);
 };
 


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase**! 
Please read the [How to Contribute](https://github.com/oceanbase/oceanbase/wiki/how_to_contribute) document **BEFORE** filling this PR.

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description
close #2117.



### Solution

<!-- Please clearly and consice descipt the solution. -->
To address this issue, we propose enhancing the DFO scheduling strategy to dynamically adjust the distribution of SQC based on the current load and resource utilization of each observer. The new strategy could:

- **Monitor CPU and resource utilization**. `ObPxTargetMgr` continuously monitor the CPU load and resource usage of each observer.

- **Adaptive distribution**. Distribute SQC based on the current load, prioritizing less loaded observers to achieve better load balancing.
