### PR TITLE
fix: check privilege when executing show create function.

### DIFF
--- a/src/observer/virtual_table/ob_show_create_procedure.cpp
+++ b/src/observer/virtual_table/ob_show_create_procedure.cpp
@@ -149,7 +149,6 @@ int ObShowCreateProcedure::fill_row_cells(uint64_t show_procedure_id, const ObRo
         }
         case OB_APP_MIN_COLUMN_ID + 2: {
           // create_routine
-          SERVER_LOG(INFO, "print column function");
           bool sql_quote_show_create = true;
           bool ansi_quotes = false;
           bool print_column_priv = false;

--- a/src/observer/virtual_table/ob_show_create_procedure.h
+++ b/src/observer/virtual_table/ob_show_create_procedure.h
@@ -15,6 +15,7 @@
 
 #include "lib/container/ob_se_array.h"
 #include "share/ob_virtual_table_scanner_iterator.h"
+#include "share/schema/ob_priv_type.h"
 #include "common/ob_range.h"
 
 namespace oceanbase
@@ -39,12 +40,29 @@ public:
   virtual ~ObShowCreateProcedure();
   virtual int inner_get_next_row(common::ObNewRow *&row);
   virtual void reset();
+
+  inline void set_tenant_id(uint64_t tenant_id) { tenant_id_ = tenant_id; }
+
+  inline void set_user_id(uint64_t user_id) { user_id_ = user_id; }
+
+  inline share::schema::ObSessionPrivInfo &get_session_priv()
+  { return session_priv_; }
+
+  inline common::ObIArray<uint64_t> &get_role_id_array()
+  { return enable_role_id_array_; }
+
+  int has_show_create_function_priv(const ObRoutineInfo &proc_info,
+                                    bool &print_create_function_column_priv) const;
 private:
   int calc_show_procedure_id(uint64_t &show_table_id);
   int fill_row_cells(uint64_t show_procedure_id,
                      const share::schema::ObRoutineInfo &proc_info);
 private:
   DISALLOW_COPY_AND_ASSIGN(ObShowCreateProcedure);
+  uint64_t tenant_id_;
+  uint64_t user_id_;
+  EnableRoleIdArray enable_role_id_array_;
+  share::schema::ObSessionPrivInfo session_priv_;
 };
 }// observer
 }// oceanbase

--- a/src/observer/virtual_table/ob_show_create_procedure.h
+++ b/src/observer/virtual_table/ob_show_create_procedure.h
@@ -41,10 +41,6 @@ public:
   virtual int inner_get_next_row(common::ObNewRow *&row);
   virtual void reset();
 
-  inline void set_tenant_id(uint64_t tenant_id) { tenant_id_ = tenant_id; }
-
-  inline void set_user_id(uint64_t user_id) { user_id_ = user_id; }
-
   inline share::schema::ObSessionPrivInfo &get_session_priv()
   { return session_priv_; }
 
@@ -59,8 +55,6 @@ private:
                      const share::schema::ObRoutineInfo &proc_info);
 private:
   DISALLOW_COPY_AND_ASSIGN(ObShowCreateProcedure);
-  uint64_t tenant_id_;
-  uint64_t user_id_;
   EnableRoleIdArray enable_role_id_array_;
   share::schema::ObSessionPrivInfo session_priv_;
 };

--- a/src/observer/virtual_table/ob_virtual_table_iterator_factory.cpp
+++ b/src/observer/virtual_table/ob_virtual_table_iterator_factory.cpp
@@ -1210,8 +1210,6 @@ int ObVTIterCreator::create_vt_iter(ObVTableScanParam &params,
           {
             ObShowCreateProcedure *create_proc = NULL;
             if (OB_SUCC(NEW_VIRTUAL_TABLE(ObShowCreateProcedure, create_proc))) {
-              create_proc->set_tenant_id(real_tenant_id);
-              create_proc->set_user_id(session->get_user_id());
               if (OB_FAIL(session->get_session_priv_info(create_proc->get_session_priv()))) {
                 SERVER_LOG(WARN, "fail to get session priv info", K(ret));
               } else if (OB_FAIL(create_proc->get_role_id_array().assign(session->get_enable_role_array()))) {

--- a/src/observer/virtual_table/ob_virtual_table_iterator_factory.cpp
+++ b/src/observer/virtual_table/ob_virtual_table_iterator_factory.cpp
@@ -1210,7 +1210,15 @@ int ObVTIterCreator::create_vt_iter(ObVTableScanParam &params,
           {
             ObShowCreateProcedure *create_proc = NULL;
             if (OB_SUCC(NEW_VIRTUAL_TABLE(ObShowCreateProcedure, create_proc))) {
-              vt_iter = static_cast<ObVirtualTableIterator *>(create_proc);
+              create_proc->set_tenant_id(real_tenant_id);
+              create_proc->set_user_id(session->get_user_id());
+              if (OB_FAIL(session->get_session_priv_info(create_proc->get_session_priv()))) {
+                SERVER_LOG(WARN, "fail to get session priv info", K(ret));
+              } else if (OB_FAIL(create_proc->get_role_id_array().assign(session->get_enable_role_array()))) {
+                SERVER_LOG(WARN, "fail to assign role id array", K(ret));
+              } else {
+                vt_iter = static_cast<ObVirtualTableIterator *>(create_proc);
+              }
             }
             break;
           }

--- a/tools/deploy/mysql_test/r/mysql/show_create_function.result
+++ b/tools/deploy/mysql_test/r/mysql/show_create_function.result
@@ -1,0 +1,38 @@
+------connect to test01------
+show create function test.f1;
+Function	sql_mode	Create Function	character_set_client	collation_connection	Database Collation
+f1	STRICT_ALL_TABLES,NO_ZERO_IN_DATE,NO_AUTO_CREATE_USER	CREATE DEFINER = `admin`@`%` FUNCTION `f1`(a INT, b INT) RETURNS int(11)
+    DETERMINISTIC
+BEGIN
+RETURN a + b;
+END	utf8mb4	utf8mb4_general_ci	utf8mb4_general_ci
+
+show create function test.f2;
+Function	sql_mode	Create Function	character_set_client	collation_connection	Database Collation
+f2	STRICT_ALL_TABLES,NO_ZERO_IN_DATE,NO_AUTO_CREATE_USER	CREATE DEFINER = `test03`@`%` FUNCTION `f2`(a INT, b INT) RETURNS int(11)
+    DETERMINISTIC
+BEGIN
+RETURN a + b; 
+END	utf8mb4	utf8mb4_general_ci	utf8mb4_general_ci
+
+------connect to test02------
+show create function test.f1;
+Function	sql_mode	Create Function	character_set_client	collation_connection	Database Collation
+f1	STRICT_ALL_TABLES,NO_ZERO_IN_DATE,NO_AUTO_CREATE_USER	NULL	utf8mb4	utf8mb4_general_ci	utf8mb4_general_ci
+
+show create function test.f2;
+Function	sql_mode	Create Function	character_set_client	collation_connection	Database Collation
+f2	STRICT_ALL_TABLES,NO_ZERO_IN_DATE,NO_AUTO_CREATE_USER	NULL	utf8mb4	utf8mb4_general_ci	utf8mb4_general_ci
+
+------connect to test03------
+show create function test.f1;
+Function	sql_mode	Create Function	character_set_client	collation_connection	Database Collation
+f1	STRICT_ALL_TABLES,NO_ZERO_IN_DATE,NO_AUTO_CREATE_USER	NULL	utf8mb4	utf8mb4_general_ci	utf8mb4_general_ci
+
+show create function test.f2;
+Function	sql_mode	Create Function	character_set_client	collation_connection	Database Collation
+f2	STRICT_ALL_TABLES,NO_ZERO_IN_DATE,NO_AUTO_CREATE_USER	CREATE DEFINER = `test03`@`%` FUNCTION `f2`(a INT, b INT) RETURNS int(11)
+    DETERMINISTIC
+BEGIN
+RETURN a + b; 
+END	utf8mb4	utf8mb4_general_ci	utf8mb4_general_ci

--- a/tools/deploy/mysql_test/t/show_create_function.test
+++ b/tools/deploy/mysql_test/t/show_create_function.test
@@ -1,0 +1,76 @@
+--disable_query_log
+set @@session.explicit_defaults_for_timestamp=off;
+--enable_query_log
+# owner : diqinhao.dqh
+# owner group: SQL
+# description:
+#
+
+--disable_query_log
+--disable_warnings
+use test;
+drop user if exists test01;
+drop user if exists test02;
+drop user if exists test03;
+
+drop function if exists test.f1;
+drop function if exists test.f2;
+--enable_warnings
+
+delimiter //; 
+CREATE FUNCTION f1(a INT, b INT) RETURNS INT DETERMINISTIC
+BEGIN
+    RETURN a + b;
+END//
+delimiter ;//
+
+create user 'test01' identified by 'test01';
+grant select on *.* to test01;
+grant execute on function test.f1 to test01;
+## flush privileges;
+
+create user test02 identified by 'test02';
+grant select on test.* to test02;
+grant create routine on test.* to test02;
+## flush privileges;
+
+create user test03 identified by 'test03';
+grant select on test.* to test03;
+grant execute on test.* to test03;
+## flush privileges;
+
+delimiter //;
+CREATE DEFINER=test03 FUNCTION f2(a INT, b INT) RETURNS INT DETERMINISTIC
+BEGIN
+    RETURN a + b; 
+END//
+delimiter ;//
+
+--enable_query_log
+
+connect (conn1,$OBMYSQL_MS0,test01@mysql,test01,test,$OBMYSQL_PORT);
+connect (conn2,$OBMYSQL_MS0,test02@mysql,test02,test,$OBMYSQL_PORT);
+connect (conn3,$OBMYSQL_MS0,test03@mysql,test03,test,$OBMYSQL_PORT);
+
+--echo ------connect to test01------
+connection conn1;
+show create function test.f1;
+--echo
+show create function test.f2;
+disconnect conn1;
+
+--echo
+--echo ------connect to test02------
+connection conn2;
+show create function test.f1;
+--echo
+show create function test.f2;
+disconnect conn2;
+
+--echo
+--echo ------connect to test03------
+connection conn3;
+show create function test.f1;
+--echo
+show create function test.f2;
+disconnect conn3;

--- a/tools/deploy/mysql_test/t/show_create_function.test
+++ b/tools/deploy/mysql_test/t/show_create_function.test
@@ -27,17 +27,14 @@ delimiter ;//
 create user 'test01' identified by 'test01';
 grant select on *.* to test01;
 grant execute on function test.f1 to test01;
-## flush privileges;
 
 create user test02 identified by 'test02';
 grant select on test.* to test02;
 grant create routine on test.* to test02;
-## flush privileges;
 
 create user test03 identified by 'test03';
 grant select on test.* to test03;
 grant execute on test.* to test03;
-## flush privileges;
 
 delimiter //;
 CREATE DEFINER=test03 FUNCTION f2(a INT, b INT) RETURNS INT DETERMINISTIC
@@ -74,3 +71,12 @@ show create function test.f1;
 --echo
 show create function test.f2;
 disconnect conn3;
+
+--disable_query_log
+connection default;
+drop function if exists test.f1;
+drop function if exists test.f2;
+
+drop user test01;
+drop user test02;
+drop user test03;


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase**! 
Please read the [How to Contribute](https://github.com/oceanbase/oceanbase/wiki/how_to_contribute) document **BEFORE** filling this PR.

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description
A user with only the execute, alter routine, or create routine permissions should not be able to see the function's definition when executing SHOW CREATE FUNCTION.
<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->

### Solution Description
According to mysql documentation, check the privilege of global-level select or routine definer before print the result.
<!-- Please clearly and consice descipt the solution. -->

### Passed Regressions

<!-- Unittest, mysql test or test it manually? -->

### Upgrade Compatibility

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

### Other Information

<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
