### PR TITLE
chore: add cmakecache in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,9 @@ cmake-build-release
 *.iml
 ## OSX dir files
 .DS_Store
+## CMakeCache
+CMakeCache.txt
+CMakeFiles/
 
 ############# src #############
 src/.settings/


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase**! 
Please read the [How to Contribute](https://github.com/oceanbase/oceanbase/wiki/how_to_contribute) document **BEFORE** filling this PR.

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description

This PR will add `CMakeCache.txt` and `CMakeFiles/` in gitignore to avoid it's been committed.

### Solution Description

As title

### Passed Regressions

Not needed.

### Upgrade Compatibility

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

### Other Information

<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
