### PR TITLE
enhancement: signal a dedicated cond on sys ls task push to cut empty-queue wakeup latency (issue #2442)

### DIFF
--- a/src/logservice/libobcdc/src/ob_log_sys_ls_task_handler.cpp
+++ b/src/logservice/libobcdc/src/ob_log_sys_ls_task_handler.cpp
@@ -35,7 +35,8 @@ int64_t ObLogSysLsTaskHandler::g_sys_ls_task_op_timeout_msec = ObLogConfig::defa
 ////////////////////////////// ObLogSysLsTaskHandler::TaskQueue //////////////////////////////
 
 ObLogSysLsTaskHandler::TaskQueue::TaskQueue() :
-    queue_()
+    queue_(),
+    not_empty_cond_(ObCond::SPIN_WAIT_NUM, common::ObWaitEventIds::CDC_COMMON_COND_WAIT)
 {}
 
 ObLogSysLsTaskHandler::TaskQueue::~TaskQueue()
@@ -52,6 +53,7 @@ int ObLogSysLsTaskHandler::TaskQueue::push(PartTransTask *task)
     LOG_ERROR("invalid task", KR(ret), K(task));
   } else {
     queue_.push(task);
+    not_empty_cond_.signal();
   }
 
   return ret;
@@ -84,7 +86,7 @@ int ObLogSysLsTaskHandler::TaskQueue::next_ready_to_handle(
     if (wait_time <= 0) {
       ret = OB_TIMEOUT;
     } else {
-      cond.timedwait(wait_time);
+      not_empty_cond_.timedwait(wait_time);
       cur_time = get_timestamp();
     }
   }

--- a/src/logservice/libobcdc/src/ob_log_sys_ls_task_handler.h
+++ b/src/logservice/libobcdc/src/ob_log_sys_ls_task_handler.h
@@ -158,6 +158,7 @@ public:
 
   private:
     SafePartTransTaskQueue  queue_;
+    common::ObCond          not_empty_cond_;
   };
 
 private:


### PR DESCRIPTION
### Task Description
see this issue https://github.com/oceanbase/oceanbase/issues/2442
SysLsTaskHandler sleeps for up to sys_ls_task_op_timeout_msec (default 100ms) when its task queue is empty.
When a new task arrives, push() doesn't wake the handler, so the handler just sits there until the sleep finishes.
We'd like `TaskQueue::push()` to wake the thread right away instead, so the ddl progress latency could be less.

### Solution Description
give TaskQueue its own not_empty_cond_, signal it in push(), and use it for the empty-queue wait; keep the externally-passed cond only for wait_formatted().
```
// before
int push(task)            { queue_.push(task); }                      // no signal
next_ready_to_handle(...) { cond.timedwait(wait_time); ... wait_formatted(.., cond); }  // shared cond

// after
int push(task)            { queue_.push(task); not_empty_cond_.signal(); }
next_ready_to_handle(...) { not_empty_cond_.timedwait(wait_time); ... wait_formatted(.., cond); }
```

### Passed Regressions
test it manually for OB 4.5.0.0 & 4.2.5.0, p50 e2e latency went down about 50ms

### Upgrade Compatibility

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

### Other Information

<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
