### PR TITLE
Fix error handling in check_with_lock_before_update_ method

### DIFF
--- a/src/rootserver/ob_system_admin_util.cpp
+++ b/src/rootserver/ob_system_admin_util.cpp
@@ -1154,7 +1154,7 @@ int ObAdminSetConfig::check_with_lock_before_update_(
       ObSqlString sub_string;
       sqlclient::ObMySQLResult *result = NULL;
       if (0 == ObString(table_name).case_compare(OB_TENANT_PARAMETER_TNAME)
-          && sub_string.assign_fmt("AND tenant_id = %lu ", tenant_id)) {
+          && OB_FAIL(sub_string.assign_fmt("AND tenant_id = %lu ", tenant_id))) {
         LOG_WARN("fail to build sub sql string", KR(ret), K(tenant_id), K(table_name));
       } else if (OB_FAIL(sql_string.assign_fmt(
               "SELECT config_version AS current_config_version "


### PR DESCRIPTION
In ObAdminSetConfig::check_with_lock_before_update_, the condition '0 == case_compare(...) && sub_string.assign_fmt(...)' is missing the OB_FAIL wrapper. When assign_fmt fails, the if-branch is taken (logs a warning) but ret is left as OB_SUCCESS, so the whole version check and SELECT ... FOR UPDATE is silently skipped and the caller proceeds to update the config row without lock/version protection.

Wrap it with OB_FAIL so that ret holds the real error code and the caller aborts the config update.

powered by ai