### PR TITLE
fix: check return codes of credential_params.append in ALTER LOCATION

### DIFF
--- a/src/sql/resolver/ddl/ob_alter_location_resolver.cpp
+++ b/src/sql/resolver/ddl/ob_alter_location_resolver.cpp
@@ -165,9 +165,10 @@ int ObAlterLocationResolver::resolve(const ParseNode &parse_tree)
         } else {
           ObString tmp;
           tmp.assign_ptr(option_node->str_value_, static_cast<int32_t>(option_node->str_len_));
-          credential_params.append(tmp);
-          if (i != num - 1) {
-            credential_params.append(common::SEPERATE_SYMBOL);
+          if (OB_FAIL(credential_params.append(tmp))) {
+            LOG_WARN("failed to append credential value", K(ret), K(option_node->value_));
+          } else if (i != num - 1 && OB_FAIL(credential_params.append(common::SEPERATE_SYMBOL))) {
+            LOG_WARN("failed to append credential separator", K(ret), K(option_node->value_));
           }
           if (OB_SUCC(ret) && option_node->value_ >= 1 && option_node->value_ <= 3) {
             ObString masked_sql;


### PR DESCRIPTION
In ob_alter_location_resolver.cpp (ALTER LOCATION ... MODIFY CREDENTIAL), the credential value append and the separator append ignore their return codes. If an append fails (allocation failure), the credential string is truncated or fields get merged without the '&' separator, and the broken credential set REPLACES the previous working credentials of the location while the DDL still returns success. For HDFS locations the krb5 fields have no completeness validation in ObHDFSStorageInfo, so the location becomes unusable with no error at DDL time.

Check both return codes and abort the resolve with the real error.

powered by ai