### PR TITLE
fix: set ret when sql_string.append_fmt fails in build_ddl_stmt_str_

### DIFF
--- a/src/share/scheduler/ob_partition_auto_split_helper.cpp
+++ b/src/share/scheduler/ob_partition_auto_split_helper.cpp
@@ -2502,7 +2502,7 @@ int ObAutoSplitArgBuilder::build_ddl_stmt_str_(
         }
       }
       if (OB_FAIL(ret)) {
-      } else if (sql_string.append_fmt(" %s(%.*s) (",
+      } else if (OB_FAIL(sql_string.append_fmt(" %s(%.*s) (",
             is_oracle_mode ? "MODIFY PARTITION BY RANGE" : ((is_multi_partkey || part_func_type == PARTITION_FUNC_TYPE_RANGE_COLUMNS) ? "PARTITION BY RANGE COLUMNS" : "PARTITION BY RANGE"),
             part_func_expr.length(), part_func_expr.ptr())) {
         LOG_WARN("failed to append fmt", K(ret));


### PR DESCRIPTION
In ObAutoSplitArgBuilder::build_ddl_stmt_str_ (auto split of a non-partitioned table), the condition 'sql_string.append_fmt(" %s(%.*s) (")' is missing the OB_FAIL wrapper. When it fails, ret stays OB_SUCCESS, so the following appends (guarded by OB_SUCC(ret)) keep succeeding and the final DDL statement string is missing the 'PARTITION BY RANGE(...) (' clause while the function still returns success. The malformed DDL text is then stored in arg.ddl_stmt_str_ for the split task and ddl history.

Wrap it with OB_FAIL so the failure aborts the DDL string construction.

powered by ai