### PR TITLE
fix: check return codes of credential_params.append in CREATE LOCATION

### DIFF
--- a/src/sql/resolver/ddl/ob_create_location_resolver.cpp
+++ b/src/sql/resolver/ddl/ob_create_location_resolver.cpp
@@ -132,9 +132,10 @@ int ObCreateLocationResolver::resolve(const ParseNode &parse_tree)
         } else {
           ObString tmp;
           tmp.assign_ptr(option_node->str_value_, static_cast<int32_t>(option_node->str_len_));
-          credential_params.append(tmp);
-          if (i != num - 1) {
-            credential_params.append(common::SEPERATE_SYMBOL);
+          if (OB_FAIL(credential_params.append(tmp))) {
+            LOG_WARN("failed to append credential value", K(ret), K(option_node->value_));
+          } else if (i != num - 1 && OB_FAIL(credential_params.append(common::SEPERATE_SYMBOL))) {
+            LOG_WARN("failed to append credential separator", K(ret), K(option_node->value_));
           }
           if (OB_SUCC(ret) && option_node->value_ >= 1 && option_node->value_ <= 3) {
             ObString masked_sql;


### PR DESCRIPTION
In ob_create_location_resolver.cpp, the credential value append 'credential_params.append(tmp)' and the separator append 'credential_params.append(common::SEPERATE_SYMBOL)' ignore their return codes. If an append fails (allocation failure), the credential string is truncated (a field is lost) or two fields are merged without the '&' separator. For HDFS locations the krb5 fields (principal/keytab/krb5conf) have no completeness validation in ObHDFSStorageInfo, so an incomplete credential set can be silently persisted while CREATE LOCATION returns success, breaking external table access later at query time.

Check both return codes and abort the resolve with the real error.

powered by ai