### PR TITLE
fix: set ret when sql.assign_fmt fails in delete_schema_object_dependency

### DIFF
--- a/src/share/schema/ob_dependency_info.cpp
+++ b/src/share/schema/ob_dependency_info.cpp
@@ -261,7 +261,7 @@ int ObDependencyInfo::delete_schema_object_dependency(common::ObISQLClient &tran
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("delete error info unexpected.", K(ret), K(tenant_id),
                                               K(dep_obj_id), K(dep_obj_type));
-  } else if (sql.assign_fmt("delete FROM %s WHERE dep_obj_id = %ld \
+  } else if (OB_FAIL(sql.assign_fmt("delete FROM %s WHERE dep_obj_id = %ld \
                                                   AND tenant_id = %ld  \
                                                   AND dep_obj_type = %ld",
             OB_ALL_TENANT_DEPENDENCY_TNAME,


### PR DESCRIPTION
…ency

In ObDependencyInfo::delete_schema_object_dependency, the 'sql.assign_fmt(...)' condition is missing the OB_FAIL wrapper. When assign_fmt fails, the LOG_WARN branch is taken but ret is left as OB_SUCCESS, so the DELETE from __all_tenant_dependency is silently skipped and the function returns success. Callers (view/routine/table replace and drop paths in ob_ddl_service, ob_create_view_helper, ob_drop_table_helper, ob_pl_compile, ob_routine_executor) then commit the DDL with stale dependency rows left behind, which can mislead later dependency checks.

Wrap it with OB_FAIL so the error is propagated and the DDL transaction rolls back.

powered by ai
