### PR TITLE
fix: set ret when where_str.append_fmt fails in histogram SQL construct_delete_column_histogram_sql

### DIFF
--- a/src/share/stat/ob_opt_stat_sql_service.cpp
+++ b/src/share/stat/ob_opt_stat_sql_service.cpp
@@ -636,7 +636,7 @@ int ObOptStatSqlService::construct_delete_column_histogram_sql(const uint64_t te
     if (OB_ISNULL(column_stats.at(i))) {
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("get unexpected null", K(ret), K(column_stats.at(i)));
-    } else if (where_str.append_fmt(" %s (%lu, %ld, %ld, %lu) %s",
+    } else if (OB_FAIL(where_str.append_fmt(" %s (%lu, %ld, %ld, %lu) %s",
                                      i != 0 ? "," : "(TENANT_ID, TABLE_ID, PARTITION_ID, COLUMN_ID) IN (",
                                      ObSchemaUtils::get_extract_tenant_id(exec_tenant_id, tenant_id),
                                      ObSchemaUtils::get_extract_schema_id(exec_tenant_id, column_stats.at(i)->get_table_id()),
@@ -676,7 +676,7 @@ int ObOptStatSqlService::check_column_histogram_valid(const uint64_t tenant_id,
     if (OB_ISNULL(column_stats.at(i))) {
       ret = OB_ERR_UNEXPECTED;
       LOG_WARN("get unexpected null", K(ret), K(column_stats.at(i)));
-    } else if (where_str.append_fmt(
+    } else if (OB_FAIL(where_str.append_fmt(
                    " %s (%lu, %ld, %ld, %lu) %s",
                    i != 0 ? "," : "(TENANT_ID, TABLE_ID, PARTITION_ID, COLUMN_ID) IN (",
                    ObSchemaUtils::get_extract_tenant_id(exec_tenant_id, tenant_id),


### PR DESCRIPTION
In ObOptStatSqlService::construct_delete_column_histogram_sql and check_column_histogram_valid, the 'where_str.append_fmt(...)' conditions inside the for-loops are missing the OB_FAIL wrapper. When one iteration fails, ret stays OB_SUCCESS and the loop keeps running: the following iterations append tuples with a wrong prefix (missing the '(TENANT_ID, ...) IN (' header or starting with ','), producing a malformed where clause; if all iterations fail, the function returns success with an empty SQL. The real allocation error is then masked by a SQL syntax error or OB_INVALID_ARGUMENT from executing the empty SQL.

Wrap both calls with OB_FAIL so the loop aborts and the real error code is propagated.

powered by ai
