### PR TITLE
fix: avoid heap use-after-free when dangling ObString in SHOW FILES IN LOCATION 

### DIFF
--- a/src/sql/resolver/cmd/ob_show_resolver.cpp
+++ b/src/sql/resolver/cmd/ob_show_resolver.cpp
@@ -2126,14 +2126,10 @@ int ObShowResolver::resolve(const ParseNode &parse_tree)
         }
         if (OB_SUCC(ret)) {
           if (sub_path.empty()) {  // oracle模式下空串会导致全表扫描, 无法利用range_key传递参数
-            ObSqlString tmp_sub_path;
-            tmp_sub_path.append("/");
-            sub_path = tmp_sub_path.string();
+            sub_path = ObString("/");
           }
           if (pattern.empty()) {  // 同
-            ObSqlString tmp_pattern;
-            tmp_pattern.append("*");
-            pattern = tmp_pattern.string();
+            pattern = ObString("*");
           }
           if (!support_pattern_type) {
             GEN_SQL_STEP_1(ObShowSqlSet::LOCATION_UTILS_LIST);


### PR DESCRIPTION
When sub_path/pattern is not specified in SHOW FILES IN LOCATION, the code assigned them from block-scoped ObSqlString via string(), which returns a shallow reference to the internal heap buffer. The ObSqlString objects are destroyed at the end of the if-block, freeing the buffer, while the subsequent GEN_SQL_STEP_2 still reads sub_path.ptr() and pattern.ptr() to build the subquery SQL -- a heap use-after-free read.

Use string literals with static storage duration instead, which also removes the unnecessary heap allocation and the unchecked append() calls.

powered by ai
