### PR TITLE
fix: set ret when sql.assign_fmt fails in ObUDRSqlService

### DIFF
--- a/src/sql/udr/ob_udr_sql_service.cpp
+++ b/src/sql/udr/ob_udr_sql_service.cpp
@@ -231,7 +231,7 @@ int ObUDRSqlService::remove_rule(ObUDRInfo &arg)
     LOG_WARN("failed to gen recyclebin rule name", K(ret));
   } else if (OB_FAIL(sql_append_hex_escape_str(arg.rule_name_, rule_name_sql_str))) {
     LOG_WARN("failed to process rule name", K(ret));
-  } else if (sql.assign_fmt("update %s set gmt_modified = now(), rule_name = '%.*s' ,\
+  } else if (OB_FAIL(sql.assign_fmt("update %s set gmt_modified = now(), rule_name = '%.*s' ,\
                             version = %ld, status = %ld \
                             where tenant_id = %lu and rule_name = %.*s",
             OB_ALL_TENANT_REWRITE_RULES_TNAME,
@@ -258,7 +258,7 @@ int ObUDRSqlService::clean_up_items_marked_for_deletion(const uint64_t tenant_id
   ObSqlString sql;
   int64_t affected_rows = 0;
   if (OB_FAIL(ret)) {
-  } else if (sql.assign_fmt("delete FROM %s WHERE status = %ld \
+  } else if (OB_FAIL(sql.assign_fmt("delete FROM %s WHERE status = %ld \
                              AND DATEDIFF(now(), gmt_modified) >= %ld",
             OB_ALL_TENANT_REWRITE_RULES_TNAME,
             static_cast<int64_t>(ObUDRInfo::DELETE_STATUS),


### PR DESCRIPTION
In ObUDRSqlService::remove_rule and clean_up_items_marked_for_deletion, the 'sql.assign_fmt(...)' conditions in the else-if chains are missing the OB_FAIL wrapper. When assign_fmt fails, the LOG_WARN branch is taken but ret is left as OB_SUCCESS, so the UPDATE (move rule to recyclebin) or DELETE (cleanup) is silently skipped while the transaction commits and the caller gets success.

Wrap both calls with OB_FAIL so the real error code is propagated.

powered by ai
