### PR TITLE
fix: avoid NULL deref and error swallowing in ForeignKeyHandle::is_self_ref_row

### DIFF
--- a/src/sql/engine/dml/ob_table_modify_op.cpp
+++ b/src/sql/engine/dml/ob_table_modify_op.cpp
@@ -608,22 +608,25 @@ int ForeignKeyHandle::is_self_ref_row(ObEvalCtx &eval_ctx,
 {
   int ret = OB_SUCCESS;
   is_self_ref = fk_arg.is_self_ref_;
-  ObDatum *name_col = NULL;
-  ObDatum *val_col = NULL;
-  for (int64_t i = 0; is_self_ref && i < fk_arg.columns_.count(); i++) {
+  for (int64_t i = 0; OB_SUCC(ret) && is_self_ref && i < fk_arg.columns_.count(); i++) {
     const int32_t name_idx = fk_arg.columns_.at(i).name_idx_;
     const int32_t val_idx = fk_arg.columns_.at(i).idx_;
     ObExprCmpFuncType cmp_func = row.at(name_idx)->basic_funcs_->null_first_cmp_;
     // TODO qubin.qb: uncomment below block revert the defensive check
     //OZ((cmp_func = (row.at(name_idx)->basic_funcs_->null_first_cmp_))
     //   != row.at(val_idx)->basic_funcs_->null_first_cmp_);
+    // name_col/val_col must be init in each loop to avoid stale datum from previous iteration.
+    ObDatum *name_col = NULL;
+    ObDatum *val_col = NULL;
     OZ(row.at(name_idx)->eval(eval_ctx, name_col));
     OZ(row.at(val_idx)->eval(eval_ctx, val_col));
     int cmp_ret = 0;
-    if (OB_FAIL(cmp_func(*name_col, *val_col, cmp_ret))) {
-      LOG_WARN("cmp failed", K(ret), K(i));
-    } else {
-      is_self_ref = (0 == cmp_ret);
+    if (OB_SUCC(ret)) {
+      if (OB_FAIL(cmp_func(*name_col, *val_col, cmp_ret))) {
+        LOG_WARN("cmp failed", K(ret), K(i));
+      } else {
+        is_self_ref = (0 == cmp_ret);
+      }
     }
   }
   return ret;


### PR DESCRIPTION
In is_self_ref_row, the loop condition did not check ret and name_col/val_col were declared outside the loop. When ObExpr::eval failed on either column, the following OZ(eval) was skipped and left val_col NULL, then cmp_func was called unconditionally via OB_FAIL(cmp_func(*name_col, *val_col, ...)) and dereferenced the NULL pointer, crashing the observer during INSERT/UPDATE/DELETE with a multi-column self-referencing foreign key.

Besides, OB_FAIL(cmp_func(...)) assigns ret unconditionally, so a successful cmp_func in a later iteration overwrote the earlier eval error and the loop kept comparing stale datums, which could yield a wrong is_self_ref and silently skip the foreign key check (OB_ERR_NO_REFERENCED_ROW / cascade actions).

Fix:
- check OB_SUCC(ret) in the loop condition so any failure terminates the loop;
- declare name_col/val_col inside the loop so no stale pointer is reused;
- guard the cmp_func call with OB_SUCC(ret) so it is never invoked when either eval failed.

Powered by AI.
