### PR TITLE
fix(tx_table): take lock_ when resetting calc_upper_trans_version_cache_

### DIFF
--- a/src/storage/tx_table/ob_tx_data_table.cpp
+++ b/src/storage/tx_table/ob_tx_data_table.cpp
@@ -184,7 +184,10 @@ int ObTxDataTable::offline()
     STORAGE_LOG(WARN, "clean memtables cache failed", KR(ret), KPC(this));
   } else {
     is_started_ = false;
-    calc_upper_trans_version_cache_.reset();
+    {
+      TCWLockGuard lock_guard(calc_upper_trans_version_cache_.lock_);
+      calc_upper_trans_version_cache_.reset();
+    }
   }
 
   return ret;


### PR DESCRIPTION
The CalcUpperTransSCNCache members (is_inited_/cache_version_/commit_versions_) must be accessed holding lock_; offline() was the only path that reset it without the lock, racing with concurrent readers/writers of get_upper_trans_version_before_given_scn (and the matching update / is_valid / calc_upper_trans_scn_ paths).

The realistic concurrent reader is ObTenantTabletSchedulerTaskMgr::SSTableGCTask (period 30s, not a compaction DAG), which calls
try_update_upper_trans_version_and_gc_sstable -> check_need_gc_or_update_ upper_trans_version -> try_get_sstable_upper_trans_version -> ls.get_upper_trans_version_before_given_scn. ObLS::offline_() only cancels compaction DAGs in offline_compaction_() and is_stopped() is false while the LS is in LS_OFFLINING/LS_OFFLINED, so the SSTableGC timer task is not quenched by LS offline. With commit_versions_ being an ObSEArray, reset() -> destroy() frees its heap buffer (>128 nodes) while the other thread is iterating/appendig under a TCRWLock, causing use-after-free or a corrupted upper_trans_version persisted into sstable meta.

Wrap the reset in a TCWLockGuard, matching ObTxDataTable::online() and the other reset/update paths. Lock-ordering (LS lock -> cache write lock) is already taken by LS online(), and the reader path inside the cache lock region does not acquire ObLS::lock_, so no deadlock is introduced.

Powered by AI