### PR TITLE
fix(mysql/ps): bound data_len from client ORA_CLOB locator

### DIFF
--- a/src/observer/mysql/obmp_stmt_execute.cpp
+++ b/src/observer/mysql/obmp_stmt_execute.cpp
@@ -2515,6 +2515,10 @@ int ObMPStmtExecute::parse_basic_param_value(ObIAllocator &allocator,
                 int64_t data_len = 0;
                 if (OB_FAIL(lob.get_lob_data_byte_len(data_len))) {
                   LOG_WARN("fail to get inrow data len", K(ret), K(lob));
+                } else if (OB_UNLIKELY(data_len < 0 || data_len > str.length())) {
+                  ret = OB_ERR_UNEXPECTED;
+                  LOG_WARN("got invalid ps lob param, data_len out of bound",
+                           K(ret), K(length), K(data_len), K(lob), K(type), K(cs_type));
                 } else {
                   extra_len = str.length() - data_len;
                 }


### PR DESCRIPTION
PS protocol COM_STMT_EXECUTE accepts fully client-controlled param type bytes. For MYSQL_TYPE_ORA_CLOB the server constructs ObLobLocatorV2 from the raw packet buffer and computes extra_len = str.length() - data_len where data_len is read from the locator's payload-size field (a client-controlled 64-bit value). ObLobLocatorV2::is_valid() only checks the 8-byte common header and does not validate the inner payload length against the buffer size, so a crafted locator with payload_size_ > length yields a negative extra_len. The subsequent copy_or_convert_str (MEMCPY(buf+extra_buf_len, src.ptr(), src.length())) and the post-copy header reattach (MEMCPY(dst.ptr(), str.ptr(), extra_len)) then perform a heap underflow write and an out-of-bounds read, causing a remote process crash (and potentially exploitable memory corruption) reachable by any authenticated client sending a single COM_STMT_EXECUTE packet.

Reject data_len outside [0, str.length()] with OB_ERR_UNEXPECTED, in the same style as the existing v1 path's get_total_size() != length check.