### PR TITLE
fix(lob): bound inrow payload range returned by ObLobLocatorV2::get_inrow_data

### DIFF
--- a/deps/oblib/src/common/object/ob_object.cpp
+++ b/deps/oblib/src/common/object/ob_object.cpp
@@ -643,7 +643,19 @@ int ObLobLocatorV2::get_inrow_data(ObString &inrow_data) const
         ret = OB_INVALID_ARGUMENT;
         COMMON_LOG(WARN, "Lob: invalid outrow data", K(ret));
       } else {
-        inrow_data.assign_ptr(disk_loc->get_inrow_data_ptr(), disk_loc->get_byte_size(disk_loc_buff.length()));
+        const char *inrow_ptr = disk_loc->get_inrow_data_ptr();
+        int64_t inrow_len = disk_loc->get_byte_size(disk_loc_buff.length());
+        if (OB_ISNULL(inrow_ptr)
+            || inrow_len < 0
+            || inrow_ptr < ptr_
+            || static_cast<uint64_t>(inrow_ptr - ptr_) + static_cast<uint64_t>(inrow_len)
+               > static_cast<uint64_t>(size_)) {
+          ret = OB_INVALID_ARGUMENT;
+          COMMON_LOG(WARN, "Lob: invalid inrow data range", K(ret), KP(inrow_ptr), K(inrow_len),
+                     KP(ptr_), K(size_));
+        } else {
+          inrow_data.assign_ptr(inrow_ptr, inrow_len);
+        }
       }
     } else if (!is_lob_disk_locator() && has_inrow_data()) {
       if (has_extern()) {


### PR DESCRIPTION
ObLobLocatorV2::get_inrow_data, in the in_row + is_init path, takes the inrow pointer from disk_loc->get_inrow_data_ptr() and the length from disk_loc->get_byte_size(handle), where the byte_size value comes directly from the on-disk ObLobData::byte_size_ field. Neither the pointer nor the length is checked against the locator buffer's own (ptr_, size_) range. ObLobLocatorV2::is_valid() validates only the 8-byte common header and therefore cannot catch an inconsistent byte_size_ in a malformed locator (notably one coming in from a client-controlled MYSQL_TYPE_ORA_CLOB PS parameter or from a deserialized rowkey/obj).

A crafted locator with is_init_=1, in_row_=1 and a byte_size_ larger than the remaining bytes after ObLobData yields an inrow_data ObString whose (ptr, length) extends past ptr_+size_. Downstream callers (ObTextStringIter::get_full_data and the result-packing path, ObTextStringIter::get_char_len, ObLobManager::append, etc.) then memcpy or charset-scan that over-long ObString, producing a heap out-of-bounds read that can be sent back to the client (information disclosure) or persisted into a stored LOB value (data corruption + information disclosure at rest).

Add an explicit (inrow_ptr, inrow_len) range check anchored to (ptr_, size_) before assign_ptr, using uint64 arithmetic to avoid pointer/integer overflow. The other branches of get_inrow_data (simple, has_extern, no-extern out-of-row) already had equivalent checks.

Powered by AI.