### PR TITLE
fix(lob): range-check inrow data before append in ObLobManager

### DIFF
--- a/src/storage/lob/ob_lob_manager.cpp
+++ b/src/storage/lob/ob_lob_manager.cpp
@@ -1017,6 +1017,12 @@ int ObLobManager::append(
     ObString data;
     if (OB_FAIL(lob.get_inrow_data(data))) {
       LOG_WARN("get inrow data int insert lob col failed", K(lob), K(data));
+    } else if (OB_UNLIKELY(data.ptr() < lob.ptr_
+                          || static_cast<uint64_t>(data.ptr() - lob.ptr_)
+                               + static_cast<uint64_t>(data.length())
+                             > static_cast<uint64_t>(lob.size_))) {
+      ret = OB_ERR_UNEXPECTED;
+      LOG_WARN("lob inrow data out of locator buffer range", K(lob), K(data));
     } else if (OB_FAIL(append(param, data))) {
       LOG_WARN("[STORAGE_LOB]lob append failed.", K(ret), K(param), K(data));
     }


### PR DESCRIPTION
ObLobManager::append(ObLobAccessParam&, ObLobLocatorV2&) for the inrow branch takes the (ptr, length) returned by
ObLobLocatorV2::get_inrow_data(data) and feeds it to the inner append(param, data) which then MEMCPYs it into a freshly prepared inrow LOB buffer. The downstream memcpy at line ~1353 has a hard size assumption equal to data.length() and is the operation that turns an over-long (ptr, length) into persistent table corruption plus persistent heap information disclosure (the OOB bytes are written to memtable and replayed back to the SELECT side).

ObLobLocatorV2::is_valid() does not bound the inner ObLobData byte_size field, so even with a successful get_inrow_data() return, defense in depth at the storage layer is needed against malformed locators (for example, a serialized rowkey/obj containing a stale or attacker-supplied byte_size_) that reach this path.

Reject (data.ptr(), data.length()) ranges that are not strictly inside (lob.ptr_, lob.ptr_ + lob.size_) with OB_ERR_UNEXPECTED, using uint64 arithmetic to avoid pointer/integer overflow. The check uses the same OB_UNLIKELY / LOG_WARN style as other guards in this file.

Powered by AI.