### PR TITLE
fix(oblog): silently dropped K() values in base64 decode WARN logs

### DIFF
--- a/deps/oblib/src/lib/encode/ob_base64_encode.cpp
+++ b/deps/oblib/src/lib/encode/ob_base64_encode.cpp
@@ -512,13 +512,13 @@ int ObBase64Encoder::decode_with_simd(const char *input,  const int64_t input_le
   #if OB_USE_MULTITARGET_CODE
   bool avx512_supported = common::is_arch_supported(ObTargetArch::AVX512);
   if (avx512_supported && OB_FAIL(specific::avx512::do_decode_with_avx512(input, input_len, output, output_len, pos, BASE64_VALUES, skip_spaces))) {
-    _OB_LOG(WARN, "input may be an illegal base64 string", K(ret), K(input_len));
+    OB_LOG(WARN, "input may be an illegal base64 string", K(ret), K(input_len));
   } else if (!avx512_supported && OB_FAIL(decode(input, input_len, output, output_len, pos, skip_spaces))) {
-    _OB_LOG(WARN, "input is not legal base64 string", K(ret), K(input_len));
+    OB_LOG(WARN, "input is not legal base64 string", K(ret), K(input_len));
   }
   #else
   if (OB_FAIL(decode(input, input_len, output, output_len, pos, skip_spaces))) {
-    _OB_LOG(WARN, "input is not legal base64 string", K(ret), K(input_len));
+    OB_LOG(WARN, "input is not legal base64 string", K(ret), K(input_len));
   }
   #endif
   return ret;


### PR DESCRIPTION
The `_OB_LOG` (underscore variant) macro adopts printf-style variadic formatting, where the second argument is the format string and subsequent arguments are passed as printf varargs. In `ObBase64Encoder::decode_with_simd`, the format string is a literal message (e.g. "input may be an illegal base64 string") without any % specifiers, but K(ret) and K(input_len) were passed as K() key-value pairs. Because the format string contains no % specifiers, `vsnprintf` silently ignores all extra varargs, so the ret error code and input_len are dropped and never appear in the log line.

Trigger: SQL `SELECT FROM_BASE64('invalid_base64!')` reaches `ob_expr_from_base64.cpp:344` -> `ObBase64Encoder::decode_with_simd`. On decode failure, the WARN log emits only the literal message, leaving operators without the error code or input length for diagnosis.

Switch to the non-underscore `OB_LOG` variant which uses K() key-value pairs.

powered by ai