### PR TITLE
fix(text-analysis): clamp ObTextWhitespaceTokenizer token length to b…

### DIFF
--- a/src/share/text_analysis/ob_token_stream.cpp
+++ b/src/share/text_analysis/ob_token_stream.cpp
@@ -107,13 +107,19 @@ int ObTextWhitespaceTokenizer::get_next(ObDatum &next_token, int64_t &token_freq
     // to next whitespace pos
     while (OB_SUCC(ret) && !found_delimiter()) {
       const int64_t c_len = ob_mbcharlen_ptr(cs_, doc + trav_pos_, doc + doc_len);
-      trav_pos_ += c_len;
-      token_len += c_len;
-      if (trav_pos_ >= doc_len || 0 == c_len) {
+      const int64_t remaining = static_cast<int64_t>(doc_len) - trav_pos_;
+      if (c_len <= 0 || c_len > remaining) {
         iter_end_ = true;
         if (0 == token_len) {
           ret = OB_ITER_END;
         }
+        trav_pos_ = doc_len;
+        break;
+      }
+      trav_pos_ += c_len;
+      token_len += c_len;
+      if (doc_len == trav_pos_) {
+        iter_end_ = true;
         break;
       }
     }


### PR DESCRIPTION
The tokenizer accumulated token_len by ob_mbcharlen_ptr()'s return value without bounding it to the remaining buffer, so a document ending with a truncated multi-byte lead byte (e.g. utf8mb4 0xE4 as last byte) produced a token whose length extended past input_doc_->ptr_ + doc_len. Downstream consumers (ObBasicEnglishNormalizer trim loop, ObCharset::tolower copy, ObBEngFTParser MEMCPY) then performed a heap out-of-bounds read.

Track remaining bytes and treat c_len <= 0 (invalid lead byte) or c_len > remaining (truncated char at buffer tail) as end-of-stream, mirroring the guard already present in ObFTNgramImpl::get_next_token.

Powered by AI.
