### PR TITLE
fix: destory raw expr factory before dtor in ObExecContext::clean_res…

### DIFF
--- a/src/sql/engine/ob_exec_context.cpp
+++ b/src/sql/engine/ob_exec_context.cpp
@@ -272,6 +272,7 @@ ObExecContext::~ObExecContext()
 void ObExecContext::clean_resolve_ctx()
 {
   if (OB_NOT_NULL(expr_factory_)) {
+    expr_factory_->destory();
     expr_factory_->~ObRawExprFactory();
     expr_factory_ = nullptr;
   }


### PR DESCRIPTION
ObRawExprFactory::~ObRawExprFactory() only invokes destory() when !THIS_WORKER.has_req_flag() && OB_ISNULL(proxy_); otherwise the caller must invoke destory() explicitly. clean_resolve_ctx() is reached from ~ObExecContext() during request worker teardown (has_req_flag()==true), so the bare ~ObRawExprFactory() call skipped expr_store_'s raw expr destructors and leaked ObSEArray<ObString>-style shared-buffer members. Match the existing ~ObExecContext() pattern used for phy_plan_ctx_ by calling destory() first, so accumulated ObRawExpr objects are properly destructed regardless of worker context.

powered by ai