### PR TITLE
fix: destory raw expr factory before dtor in ObMVProvider::~ObMVProvider

### DIFF
--- a/src/sql/resolver/mv/ob_mv_provider.cpp
+++ b/src/sql/resolver/mv/ob_mv_provider.cpp
@@ -35,6 +35,7 @@ ObMVProvider::~ObMVProvider()
     stmt_factory_ = NULL;
   }
   if (NULL != expr_factory_) {
+    expr_factory_->destory();
     expr_factory_->~ObRawExprFactory();
     expr_factory_ = NULL;
   }


### PR DESCRIPTION
ObRawExprFactory::~ObRawExprFactory() only invokes destory() when !THIS_WORKER.has_req_flag() && OB_ISNULL(proxy_); otherwise the caller must invoke destory() explicitly. ObMVProvider::init_mv_provider() constructs the factory via placement new and the instance is used in MV refresh paths (ob_mview_refresh.cpp / compaction util / mlog trim task) that run in request worker context. ~ObMVProvider() invoked ~ObRawExprFactory() directly, skipping expr_store_'s raw expr destructors and leaking ObSEArray<ObString>-style shared-buffer members. Match the pattern already used in ObCalcGeneratedColumn::destroy() by calling destory() first, so the accumulated ObRawExpr objects created during MV resolution are properly destructed regardless of worker context.

powered by ai