### PR TITLE
fix(storage): fix UAF and table store corruption when reusing split s…

### DIFF
--- a/src/storage/high_availability/ob_sstable_copy_finish_task.cpp
+++ b/src/storage/high_availability/ob_sstable_copy_finish_task.cpp
@@ -354,8 +354,7 @@ ObSSTableCopyFinishTask::ObSSTableCopyFinishTask()
     sstable_index_builder_(false /* not use writer buffer*/),
     restore_macro_block_id_mgr_(nullptr),
     macro_block_reuse_mgr_(),
-    allocator_(ObMemAttr(MTL_ID(), "SSTCopyFinish")),
-    split_src_sstable_handle_()
+    allocator_(ObMemAttr(MTL_ID(), "SSTCopyFinish"))
 {
 }
 
@@ -1187,6 +1186,7 @@ int ObSSTableCopyFinishTask::build_split_src_sstable_reuse_info_()
   int ret = OB_SUCCESS;
   ObTabletHandle tablet_handle;
   ObTabletHandle split_src_tablet_handle;
+  ObTableHandleV2 split_src_sstable_handle;
   ObTablet *tablet = nullptr;
   ObTablet *split_src_tablet = nullptr;
   ObTabletID src_tablet_id;
@@ -1249,13 +1249,12 @@ int ObSSTableCopyFinishTask::build_split_src_sstable_reuse_info_()
   } else if (OB_ISNULL(sstable = sstable_wrapper.get_sstable())) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("sstable should not be NULL", K(ret), KP(sstable), KPC(sstable_param_));
-  } else if (OB_FAIL(split_src_sstable_handle_.set_sstable(sstable, &allocator_))) {
-    // hold this sstable until copy task finish
+  } else if (OB_FAIL(split_src_sstable_handle.set_sstable_with_tablet(sstable))) {
     LOG_WARN("failed to set sstable with tablet", K(ret), KPC(sstable_param_));
-  } else if (OB_FAIL(build_major_sstable_reuse_info_(split_src_sstable_handle_, split_src_tablet_handle))) {
+  } else if (OB_FAIL(build_major_sstable_reuse_info_(split_src_sstable_handle, split_src_tablet_handle))) {
     LOG_WARN("failed to build major sstable reuse info", K(ret), KPC(sstable_param_));
   } else {
-    LOG_INFO("succeed build major sstable reuse info", K(split_src_tablet_handle), K(split_src_sstable_handle_), KPC(sstable_param_));
+    LOG_INFO("succeed build major sstable reuse info", K(split_src_tablet_handle), K(split_src_sstable_handle), KPC(sstable_param_));
   }
   return ret;
 }

--- a/src/storage/high_availability/ob_sstable_copy_finish_task.h
+++ b/src/storage/high_availability/ob_sstable_copy_finish_task.h
@@ -284,7 +284,6 @@ private:
   ObRestoreMacroBlockIdMgr *restore_macro_block_id_mgr_;
   ObMacroBlockReuseMgr macro_block_reuse_mgr_;
   common::ObArenaAllocator allocator_;
-  ObTableHandleV2 split_src_sstable_handle_;
   DISALLOW_COPY_AND_ASSIGN(ObSSTableCopyFinishTask);
 };
 


### PR DESCRIPTION
ObSSTableCopyFinishTask::build_split_src_sstable_reuse_info_() fetched the major sstable of the split source tablet from its table store. That pointer is an unloaded stub owned by the tablet memory in t3m, but the code handed it to ObTableHandleV2::set_sstable(sstable, &allocator_), which registers the task arena as the owner of the sstable ("only used when create stand alone sstable").

When the task was destroyed, ObTableHandleV2::reset() saw ref_cnt == 0 and ran table_->~ObITable() followed by allocator_->free(table_) on that stub:
- the explicit destructor call virtually dispatches to ~ObSSTable(), which resets the table key and the read state of a stub that is still referenced by the split src tablet's table store, corrupting that tablet if it is still alive in t3m;
- if the split src tablet has already been deleted during the macro block copy, the dec_ref and the destructor run on freed memory (use-after-free);
- the arena free itself is a cross allocator free of foreign memory.

Now the handle is a local variable and is created with set_sstable_with_tablet(), the form used by build_latest_major_sstable_ reuse_info_() for the same kind of tablet owned sstable. reset() only drops the reference and frees nothing, and it runs before the local tablet handle is destroyed, so the stub memory is still valid.

Powered by AI
