### PR TITLE
fix(rs): guard NULL orig_column_schema in ObModifyAutoincTask::modify…

### DIFF
--- a/src/rootserver/ddl_task/ob_modify_autoinc_task.cpp
+++ b/src/rootserver/ddl_task/ob_modify_autoinc_task.cpp
@@ -349,7 +349,7 @@ int ObModifyAutoincTask::modify_autoinc()
       ret = OB_TABLE_NOT_EXIST;
       LOG_WARN("cannot find orig table", K(ret), K(alter_table_arg_));
     } else {
-      int64_t alter_column_id = 0;
+      int64_t alter_column_id = OB_INVALID_ID;
 
       ObTableSchema::const_column_iterator iter = alter_table_schema.column_begin();
       ObTableSchema::const_column_iterator iter_end = alter_table_schema.column_end();
@@ -361,7 +361,9 @@ int ObModifyAutoincTask::modify_autoinc()
         } else {
           const ObString &orig_column_name = alter_column_schema->get_origin_column_name();
           const ObColumnSchemaV2 *orig_column_schema = orig_table_schema->get_column_schema(orig_column_name);
-          if (alter_column_schema->is_autoincrement() && !orig_column_schema->is_autoincrement()) {
+          if (OB_NOT_NULL(orig_column_schema)
+              && alter_column_schema->is_autoincrement()
+              && !orig_column_schema->is_autoincrement()) {
             alter_column_id = orig_column_schema->get_column_id();
             break; // there can only be one autoinc column
           }


### PR DESCRIPTION
ObTableSchema::get_column_schema(const ObString&) returns NULL when the column name is not found in the schema. In ObModifyAutoincTask::modify_autoinc the result was dereferenced unconditionally on the next line to compare the autoincrement flag. The async DDL executor fetches orig_table_schema fresh from the schema service at execution time, so a concurrent DROP COLUMN (or any DDL that removes the column) between task creation and task execution — including tasks that are persisted to __all_ddl_task_status and re-run after an RS restart — would leave orig_column_schema == NULL and crash the rootserver worker thread.

Two changes:
  1. Guard the deref with OB_NOT_NULL on the existing chain of conditions, short-circuiting when orig_column_schema is NULL.
  2. Initialise alter_column_id with OB_INVALID_ID (instead of 0) so the existing post-loop 'alter_column_id == OB_INVALID_ID' check actually fires when no autoincrement candidate is found; without this the code would still fall through to get_column_schema(alter_column_id) and crash on the dropped-column path.

Powered by AI.