### PR TITLE
fix: skip rdtscp when CPUID does not advertise it

### DIFF
--- a/deps/easy/src/util/easy_time.c
+++ b/deps/easy/src/util/easy_time.c
@@ -112,6 +112,27 @@ int is_support_invariant_tsc()
     return ret;
 }
 
+// 判断是否支持 RDTSCP, 入口在 CPUID.80000001H:EDX[27].
+// Hypervisors (e.g. Docker Desktop on Intel macOS) may expose invariant TSC
+// without RDTSCP; executing the instruction then raises SIGILL.
+static int is_support_rdtscp()
+{
+    int ret = 0;
+
+#if defined(__x86_64__)
+    unsigned int cpu_info[4];
+    cpu_info[3] = 0;
+    if (__get_cpuid(0x80000001, cpu_info, cpu_info + 1, cpu_info + 2, cpu_info + 3)
+        && (cpu_info[3] & (1u << 27))) {
+        ret = 1;
+    }
+#else
+    ret = 1;
+#endif
+
+    return ret;
+}
+
 typedef struct ObTscTimestampStruct {
     int64_t start_us;
     uint64_t tsc_count;
@@ -248,7 +269,7 @@ void build_tsc_timestamp()
             struct timeval tv;
             gettimeofday(&tv, NULL);
             tsc_obj.start_us = tv.tv_sec * 1000000 + tv.tv_usec;
-            tsc_obj.tsc_count = rdtscp();
+            tsc_obj.tsc_count = is_support_rdtscp() ? rdtscp() : rdtsc();
             if (tsc_obj.tsc_count > 0 && cpu_freq_khz > 0) {
                 tsc_obj.scale = (1000 << 20) / cpu_freq_khz;
                 tsc_obj.use_tsc = 1;

--- a/deps/easy/test/util/easy_time_test.c
+++ b/deps/easy/test/util/easy_time_test.c
@@ -53,3 +53,12 @@ TEST(easy_time, now)
     e /= 1000000;
     EXPECT_TRUE(s == t || e == t);
 }
+
+TEST(easy_time, fast_current_time)
+{
+    int64_t                 s = fast_current_time();
+    usleep(1000);
+    int64_t                 e = fast_current_time();
+    EXPECT_TRUE(s > 0);
+    EXPECT_TRUE(e > 0);
+}

--- a/deps/oblib/src/lib/time/ob_tsc_timestamp.cpp
+++ b/deps/oblib/src/lib/time/ob_tsc_timestamp.cpp
@@ -35,7 +35,11 @@ int ObTscTimestamp::init()
       LIB_LOG(WARN, "invariant TSC not support", K(ret));
     } else {
       const int64_t cpu_freq_khz = get_cpufreq_khz_();
+#if defined(__x86_64__)
+      tsc_count_ = is_support_rdtscp_() ? rdtscp() : rdtsc();
+#else
       tsc_count_ = rdtscp();
+#endif
       start_us_ = tv.tv_sec * 1000000 + tv.tv_usec;
       // judge if cpu frequency and tsc are legal
       if (tsc_count_ > 0 && cpu_freq_khz > 0) {
@@ -123,16 +127,15 @@ bool ObTscTimestamp::is_support_invariant_tsc_()
   } else {
     ret = false;
   }
-  if (ret) {
-    cpu_info[3] = 0;
-    getcpuid(cpu_info, 0x80000001);
-    if (cpu_info[3] & (1<<27)) {
-      // RDTSCP is supported
-    } else {
-      ret = false;
-    }
-  }
   return ret;
+}
+
+bool ObTscTimestamp::is_support_rdtscp_()
+{
+  unsigned int cpu_info[4];
+  cpu_info[3] = 0;
+  getcpuid(cpu_info, 0x80000001);
+  return (cpu_info[3] & (1U << 27)) != 0;
 }
 
 #elif defined(__aarch64__)

--- a/deps/oblib/src/lib/time/ob_tsc_timestamp.h
+++ b/deps/oblib/src/lib/time/ob_tsc_timestamp.h
@@ -132,6 +132,8 @@ private:
   uint64_t get_cpufreq_khz_();
   // judge if it support tsc, entry is CPUID.80000007H:EDX[8].
   bool is_support_invariant_tsc_();
+  // CPUID.80000001H:EDX[27]
+  bool is_support_rdtscp_();
 #elif defined(__aarch64__)
   uint64_t get_cpufreq_khz_(void);
   bool is_support_invariant_tsc_()


### PR DESCRIPTION
### Task Description

Fixes #2441.

`observer` executes `rdtscp` during startup and dies with SIGILL on hypervisors that do not expose RDTSCP (Docker Desktop on Intel macOS). The crash is in `fast_current_time` → `build_tsc_timestamp()`.

### Solution Description

`build_tsc_timestamp()` in `deps/easy/src/util/easy_time.c` used `rdtscp` after only checking invariant TSC (`CPUID.80000007H:EDX[8]`). That is not enough: some VMs advertise invariant TSC without `CPUID.80000001H:EDX[27]` (RDTSCP).

This change:

- checks RDTSCP via CPUID before executing the instruction
- falls back to `rdtsc` for the TSC baseline (the hot path already used `rdtsc`)
- applies the same gate in `ObTscTimestamp::init()`

The TSC fast path still works when invariant TSC is present; only the serializing `rdtscp` read is skipped when the ISA bit is clear.

### Passed Regressions

- Existing `easy_time` tests plus a `fast_current_time` smoke test
- Linked `easy_time.c` and ran `fast_current_time()` on a CPU without RDTSCP (`qemu-x86_64 -cpu qemu64`): unguarded `rdtscp` SIGILLs; patched path returns a valid timestamp

Full observer Compile/Farm is expected from CI.

### Upgrade Compatibility

Compatible. No protocol, storage, or on-disk format change. On hosts without RDTSCP, time sampling uses `rdtsc` (or `gettimeofday` if invariant TSC is also missing) instead of crashing.

### Other Information

Suggested by the reporter of #2441 (`CPUID.80000001H:EDX[27]`, fallback to `rdtsc`).

### Release Note

Fix observer SIGILL at startup on platforms that do not expose RDTSCP.

Made with [Cursor](https://cursor.com)